### PR TITLE
Remove type parameter from the StagedBatch trait

### DIFF
--- a/src/main/scala/services/consumers/SqlServerChangeTracking.scala
+++ b/src/main/scala/services/consumers/SqlServerChangeTracking.scala
@@ -37,7 +37,7 @@ object SqlServerChangeTrackingBackfillQuery:
     OverwriteReplaceQuery(sourceQuery, targetName, tablePropertiesSettings)
 
 class SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings)
-  extends StagedBackfillBatch:
+  extends StagedBackfillOverwriteBatch:
   
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
@@ -53,7 +53,7 @@ object  SqlServerChangeTrackingBackfillBatch:
   /**
    *
    */
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillBatch =
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
     new SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
 
 class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch:

--- a/src/main/scala/services/consumers/StagedBatch.scala
+++ b/src/main/scala/services/consumers/StagedBatch.scala
@@ -5,7 +5,11 @@ import models.querygen.{InitializeQuery, MergeQuery, OverwriteQuery, OverwriteRe
 import models.ArcaneSchema
 
 
-trait StagedBatch[Query <: StreamingBatchQuery]:
+trait StagedBatch:
+
+  type Query <: StreamingBatchQuery
+
+
   /**
    * Name of the table in the linked Catalog that holds batch data
    */
@@ -35,14 +39,23 @@ trait StagedBatch[Query <: StreamingBatchQuery]:
 /**
  * StagedBatch that overwrites the whole table and all partitions that it might have
  */
-type StagedInitBatch = StagedBatch[InitializeQuery]
+trait StagedInitBatch extends StagedBatch:
+  override type Query = InitializeQuery
 
 /**
- * StagedBatch that overwrites the whole table and all partitions that it might have
+ * StagedBatch that performs a backfill operation on the table in CREATE OR REPLACE mode
  */
-type StagedBackfillBatch = StagedBatch[OverwriteQuery]
+trait StagedBackfillOverwriteBatch extends StagedBatch:
+  override type Query = OverwriteQuery
+
+/**
+ * StagedBatch that performs a backfill operation on the table in MERGE mode
+ */
+trait StagedBackfillMergeBatch extends StagedBatch:
+  override type Query = MergeQuery
 
 /**
  * StagedBatch that updates data in the table
  */
-type StagedVersionedBatch = StagedBatch[MergeQuery]
+trait StagedVersionedBatch extends StagedBatch:
+  override type Query = MergeQuery

--- a/src/main/scala/services/consumers/SynapseLink.scala
+++ b/src/main/scala/services/consumers/SynapseLink.scala
@@ -37,7 +37,7 @@ object SynapseLinkBackfillQuery:
     OverwriteReplaceQuery(sourceQuery, targetName, tablePropertiesSettings)
 
 class SynapseLinkBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings)
-  extends StagedBackfillBatch:
+  extends StagedBackfillOverwriteBatch:
 
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
@@ -57,7 +57,7 @@ object  SynapseLinkBackfillBatch:
   /**
    *
    */
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillBatch =
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
     new SynapseLinkBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
 
 class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch:

--- a/src/main/scala/services/streaming/processors/MergeProcessor.scala
+++ b/src/main/scala/services/streaming/processors/MergeProcessor.scala
@@ -14,7 +14,7 @@ import zio.{ZIO, ZLayer}
  * @param jdbcConsumer The JDBC consumer.
  */
 class MergeProcessor(jdbcConsumer: JdbcConsumer[StagedVersionedBatch])
-  extends BatchProcessor[StagedBatch[MergeQuery], BatchApplicationResult]:
+  extends BatchProcessor[StagedVersionedBatch, BatchApplicationResult]:
 
   /**
    * Processes the incoming data.


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-framework-scala/issues/23

This refactoring is required to simplify working with the instances of the `StagedBatch` class