### PR TITLE
Add common interface for all backfill batches

### DIFF
--- a/src/main/scala/services/consumers/StagedBatch.scala
+++ b/src/main/scala/services/consumers/StagedBatch.scala
@@ -37,21 +37,26 @@ trait StagedBatch:
 
 
 /**
- * StagedBatch that overwrites the whole table and all partitions that it might have
+ * StagedBatch initializes the table.
  */
 trait StagedInitBatch extends StagedBatch:
   override type Query = InitializeQuery
 
 /**
- * StagedBatch that performs a backfill operation on the table in CREATE OR REPLACE mode
+ * Common trait for StagedBatch that performs a backfill operation on the table.
  */
-trait StagedBackfillOverwriteBatch extends StagedBatch:
+trait StagedBackfillBatch extends StagedBatch
+
+/**
+ * StagedBatch that performs a backfill operation on the table in CREATE OR REPLACE mode.
+ */
+trait StagedBackfillOverwriteBatch extends StagedBackfillBatch:
   override type Query = OverwriteQuery
 
 /**
- * StagedBatch that performs a backfill operation on the table in MERGE mode
+ * StagedBatch that performs a backfill operation on the table in MERGE mode.
  */
-trait StagedBackfillMergeBatch extends StagedBatch:
+trait StagedBackfillMergeBatch extends StagedBackfillBatch:
   override type Query = MergeQuery
 
 /**

--- a/src/main/scala/services/consumers/SynapseLink.scala
+++ b/src/main/scala/services/consumers/SynapseLink.scala
@@ -60,7 +60,7 @@ object  SynapseLinkBackfillBatch:
   def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
     new SynapseLinkBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
 
-class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch:
+class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch with StagedBackfillMergeBatch:
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
 

--- a/src/main/scala/services/consumers/SynapseLink.scala
+++ b/src/main/scala/services/consumers/SynapseLink.scala
@@ -57,7 +57,7 @@ object  SynapseLinkBackfillBatch:
   /**
    *
    */
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkBackfillBatch =
     new SynapseLinkBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
 
 class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch with StagedBackfillMergeBatch:
@@ -76,5 +76,5 @@ class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, target
   override def archiveExpr(archiveTableName: String): String = s"INSERT INTO $archiveTableName $reduceExpr"
 
 object SynapseLinkMergeBatch:
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch =
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkMergeBatch =
     new SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, batchSchema.mergeKey.name)


### PR DESCRIPTION
Part of #23

Added the common interface for the `StagedBackfillMergeBatch` and `StagedBackfillOverwriteBatch`.