### PR TITLE
Add schema to reduce expression in archiveExpr method

### DIFF
--- a/src/main/scala/models/ArcaneSchema.scala
+++ b/src/main/scala/models/ArcaneSchema.scala
@@ -82,3 +82,8 @@ object ArcaneSchema:
    * @return An empty ArcaneSchema.
    */
   def empty(): ArcaneSchema = Seq.empty
+
+  /**
+   * Converts a schema to an SQL column expression.
+   */
+  extension (schema: ArcaneSchema) def toColumnsExpression: String = s"(${schema.map(f => f.name).mkString(", ")})"

--- a/src/main/scala/models/settings/ArchiveTableSettings.scala
+++ b/src/main/scala/models/settings/ArchiveTableSettings.scala
@@ -1,0 +1,27 @@
+package com.sneaksanddata.arcane.framework
+package models.settings
+
+/**
+ * Settings for the archive table
+ */
+trait ArchiveTableSettings:
+  
+  /**
+   * Full name of the archive table
+   */
+  val fullName: String
+  
+  /**
+   * Optimize settings for the archive table
+   */
+  val optimizeSettings: OptimizeSettings
+  
+  /**
+   * Snapshot expiration settings for the archive table
+   */
+  val snapshotExpirationSettings: SnapshotExpirationSettings
+  
+  /**
+   * Orphan files expiration settings for the archive table
+   */
+  val orphanFileExpirationSettings: OrphanFilesExpirationSettings

--- a/src/main/scala/models/settings/OptimizeSettings.scala
+++ b/src/main/scala/models/settings/OptimizeSettings.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package models.settings
+
+/**
+ * Settings for optimizing the data table
+ */
+trait OptimizeSettings:
+  
+  /**
+   * Number of batches to trigger optimization
+   */
+  val batchThreshold: Int
+  
+  /**
+   * Optimize when the file size exceeds this threshold
+   */
+  val fileSizeThreshold: String

--- a/src/main/scala/models/settings/OrphanFilesExpirationSettings.scala
+++ b/src/main/scala/models/settings/OrphanFilesExpirationSettings.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package models.settings
+
+/**
+ * Settings for orphan files expiration
+ */
+trait OrphanFilesExpirationSettings:
+
+  /**
+   * Number of batches to trigger orphan files expiration
+   */
+  val batchThreshold: Int
+
+  /**
+   * Retention threshold for orphan files expiration
+   */
+  val retentionThreshold: String

--- a/src/main/scala/models/settings/SnapshotExpirationSettings.scala
+++ b/src/main/scala/models/settings/SnapshotExpirationSettings.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package models.settings
+
+/**
+ * Settings for snapshot expiration
+ */
+trait SnapshotExpirationSettings:
+  
+  /**
+   * Number of batches to trigger snapshot expiration
+   */
+  val batchThreshold: Int
+  
+  /**
+   * Retention threshold for snapshot expiration
+   */
+  val retentionThreshold: String

--- a/src/main/scala/services/consumers/SqlServerChangeTracking.scala
+++ b/src/main/scala/services/consumers/SqlServerChangeTracking.scala
@@ -36,7 +36,7 @@ object SqlServerChangeTrackingBackfillQuery:
   def apply(targetName: String, sourceQuery: String, tablePropertiesSettings: TablePropertiesSettings): OverwriteQuery =
     OverwriteReplaceQuery(sourceQuery, targetName, tablePropertiesSettings)
 
-class SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings)
+class SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, archiveName: String, tablePropertiesSettings: TablePropertiesSettings)
   extends StagedBackfillOverwriteBatch:
   
   override val name: String = batchName
@@ -49,14 +49,17 @@ class SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: Arcan
 
   def archiveExpr(archiveTableName: String): String = s"INSERT OVERWRITE $archiveTableName $reduceExpr"
 
+  override def archiveExpr(actualSchema: ArcaneSchema): String =
+    s"INSERT INTO $archiveName ${actualSchema.toColumnsExpression} $reduceExpr"
+
 object  SqlServerChangeTrackingBackfillBatch:
   /**
    *
    */
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
-    new SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, archiveName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
+    new SqlServerChangeTrackingBackfillBatch(batchName, batchSchema, targetName, archiveName, tablePropertiesSettings)
 
-class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch:
+class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, archiveName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch:
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
 
@@ -73,6 +76,9 @@ class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSc
 
   def archiveExpr(archiveTableName: String): String = s"INSERT INTO $archiveTableName $reduceExpr"
 
+  override def archiveExpr(actualSchema: ArcaneSchema): String =
+    s"INSERT INTO $archiveName ${actualSchema.toColumnsExpression} $reduceExpr"
+
 object SqlServerChangeTrackingMergeBatch:
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch =
-    new SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, batchSchema.mergeKey.name)
+  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, archiveName: String, tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch =
+    new SqlServerChangeTrackingMergeBatch(batchName, batchSchema, targetName, archiveName, tablePropertiesSettings, batchSchema.mergeKey.name)

--- a/src/main/scala/services/consumers/StagedBatch.scala
+++ b/src/main/scala/services/consumers/StagedBatch.scala
@@ -34,6 +34,12 @@ trait StagedBatch:
    * @return SQL query text
    */
   def archiveExpr(archiveTableName: String): String
+  
+  /**
+   * Query that should be used to archive this batch data
+   * @return SQL query text
+   */
+  def archiveExpr(arcaneSchema: ArcaneSchema): String
 
 
 /**

--- a/src/main/scala/services/streaming/consumers/IcebergStreamingConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergStreamingConsumer.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.streaming.consumers
 
 import models.app.StreamContext
-import models.settings.{SinkSettings, TablePropertiesSettings}
+import models.settings.{ArchiveTableSettings, SinkSettings, TablePropertiesSettings}
 import models.{ArcaneSchema, DataRow}
 import services.base.SchemaProvider
 import services.consumers.{BatchApplicationResult, SqlServerChangeTrackingMergeBatch, StagedVersionedBatch}
@@ -34,6 +34,7 @@ trait StreamingConsumer extends BatchConsumer[Chunk[DataRow]]
  */
 class IcebergStreamingConsumer(streamContext: StreamContext,
                                sinkSettings: SinkSettings,
+                               archiveTableSettings: ArchiveTableSettings,
                                tablePropertiesSettings: TablePropertiesSettings,
                                catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
                                schemaProvider: SchemaProvider[ArcaneSchema],
@@ -66,7 +67,7 @@ class IcebergStreamingConsumer(streamContext: StreamContext,
     for
       arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
       table <- ZIO.fromFuture(implicit ec => catalogWriter.write(rows, name, arcaneSchema))
-    yield table.toStagedBatch(arcaneSchema, sinkSettings.sinkLocation, tablePropertiesSettings)
+    yield table.toStagedBatch(arcaneSchema, sinkSettings.sinkLocation, archiveTableSettings.fullName, tablePropertiesSettings)
 
 object IcebergStreamingConsumer:
   val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
@@ -76,9 +77,10 @@ object IcebergStreamingConsumer:
 
   extension (table: Table) def toStagedBatch(batchSchema: ArcaneSchema,
                                              targetName: String,
+                                             archiveName: String,
                                              tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch =
     val batchName = table.name().split('.').last
-    SqlServerChangeTrackingMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings)
+    SqlServerChangeTrackingMergeBatch(batchName, batchSchema, targetName, archiveName, tablePropertiesSettings)
 
 
   /**
@@ -92,11 +94,12 @@ object IcebergStreamingConsumer:
    */
   def apply(streamContext: StreamContext,
             sinkSettings: SinkSettings,
+            archiveTableSettings: ArchiveTableSettings,
             tablePropertiesSettings: TablePropertiesSettings,
             catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
             schemaProvider: SchemaProvider[ArcaneSchema],
             mergeProcessor: BatchProcessor[StagedVersionedBatch, Boolean]): IcebergStreamingConsumer =
-    new IcebergStreamingConsumer(streamContext, sinkSettings, tablePropertiesSettings, catalogWriter, schemaProvider, mergeProcessor)
+    new IcebergStreamingConsumer(streamContext, sinkSettings, archiveTableSettings, tablePropertiesSettings, catalogWriter, schemaProvider, mergeProcessor)
 
   /**
    * The required environment for the IcebergConsumer.
@@ -107,6 +110,7 @@ object IcebergStreamingConsumer:
     & StreamContext
     & SinkSettings
     & TablePropertiesSettings
+    & ArchiveTableSettings
 
   /**
    * The ZLayer that creates the IcebergConsumer.
@@ -116,9 +120,10 @@ object IcebergStreamingConsumer:
       for
         streamContext <- ZIO.service[StreamContext]
         sinkSettings <- ZIO.service[SinkSettings]
+        archiveTableSettings <- ZIO.service[ArchiveTableSettings]
         tablePropertiesSettings <- ZIO.service[TablePropertiesSettings]
         catalogWriter <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
         schemaProvider <- ZIO.service[SchemaProvider[ArcaneSchema]]
         mergeProcessor <- ZIO.service[BatchProcessor[StagedVersionedBatch, Boolean]]
-      yield IcebergStreamingConsumer(streamContext, sinkSettings, tablePropertiesSettings, catalogWriter, schemaProvider, mergeProcessor)
+      yield IcebergStreamingConsumer(streamContext, sinkSettings, archiveTableSettings, tablePropertiesSettings, catalogWriter, schemaProvider, mergeProcessor)
     }

--- a/src/test/scala/services/consumers/SqlServerChangeTrackingTests.scala
+++ b/src/test/scala/services/consumers/SqlServerChangeTrackingTests.scala
@@ -2,11 +2,11 @@ package com.sneaksanddata.arcane.framework
 package services.consumers
 
 import models.ArcaneType.StringType
+import models.settings.TableFormat.PARQUET
 import models.settings.{TableFormat, TablePropertiesSettings}
 import models.{Field, MergeKeyField}
 import utils.{CustomTablePropertiesSettings, TestTablePropertiesSettings}
 
-import com.sneaksanddata.arcane.framework.models.settings.TableFormat.PARQUET
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -61,7 +61,7 @@ class SqlServerChangeTrackingTests extends AnyFlatSpec with Matchers:
         name = "colB",
         fieldType = StringType
       )
-    ), "test.table_a", TestTablePropertiesSettings)
+    ), "test.table_a", "test.archive_table_a", TestTablePropertiesSettings)
 
     val expected = Using(Source.fromURL(getClass.getResource("/generate_a_valid_sql_ct_backfill_batch_query.sql"))) {
       _.getLines().mkString("\n")
@@ -83,6 +83,7 @@ class SqlServerChangeTrackingTests extends AnyFlatSpec with Matchers:
         )
       ),
       "test.table_a",
+      "test.archive_table_a",
       CustomTablePropertiesSettings(Seq("bucket(colA, 32)"))
     )
 

--- a/src/test/scala/services/consumers/SynapseLinkTests.scala
+++ b/src/test/scala/services/consumers/SynapseLinkTests.scala
@@ -78,7 +78,7 @@ class SynapseLinkTests extends AnyFlatSpec with Matchers:
         name = "Id",
         fieldType = StringType
       )
-    ), "test.table_a", TestTablePropertiesSettings)
+    ), "test.table_a", "test.archive_table_a", TestTablePropertiesSettings)
 
     val expected = Using(Source.fromURL(getClass.getResource("/generate_a_valid_synapse_link_backfill_batch_query.sql"))) {
       _.getLines().mkString("\n")
@@ -108,6 +108,7 @@ class SynapseLinkTests extends AnyFlatSpec with Matchers:
       )
     ),
       "test.table_a",
+      "test.archive_table_a",
       CustomTablePropertiesSettings(Seq("bucket(colA, 32)", "year(colB)"))
     )
 


### PR DESCRIPTION
Part of #29

To be able to archive batches with different schemas, we need to provide the actual schema to archive expression.
Old version of the `archiveExpr` method to be removed in next PRs