### PR TITLE
Move Cdm Schema provider

### DIFF
--- a/src/main/scala/models/cdm/SimpleCdmModel.scala
+++ b/src/main/scala/models/cdm/SimpleCdmModel.scala
@@ -1,15 +1,10 @@
 package com.sneaksanddata.arcane.framework
 package models.cdm
 
-import models.{ArcaneSchema, ArcaneSchemaField, ArcaneType, Field, MergeKeyField}
-import services.storage.models.azure.AdlsStoragePath
-import com.sneaksanddata.arcane.framework.services.storage.services.AzureBlobStorageReader
+import models.*
 
 import upickle.default.*
-import zio.{Task, ZIO}
 
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
 import scala.language.implicitConversions
 
 /**
@@ -62,17 +57,8 @@ given Conversion[SimpleCdmEntity, ArcaneSchema] with
   override def apply(entity: SimpleCdmEntity): ArcaneSchema = entity.attributes.map(implicitly) :+ MergeKeyField
 
 object SimpleCdmModel:
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
   // number of fields in the schema of each entity which do not originate from CDM
   // currently MergeKeyField only
   val systemFieldCount: Int = 1
 
-  def apply(rootPath: String, reader: AzureBlobStorageReader): Task[SimpleCdmModel] =
-    AdlsStoragePath(rootPath).map(_ + "model.json") match {
-      case Success(modelPath) => reader.streamBlobContent(modelPath).map { reader =>
-        val model = read[SimpleCdmModel](reader.readLine())
-        reader.close()
-        model
-      }
-      case Failure(ex) => ZIO.fail(ex)
-    }
+  def apply(json: String): SimpleCdmModel = read[SimpleCdmModel](json)

--- a/src/main/scala/services/base/SchemaProvider.scala
+++ b/src/main/scala/services/base/SchemaProvider.scala
@@ -3,6 +3,8 @@ package services.base
 
 import models.ArcaneType
 
+import zio.Task
+
 import scala.concurrent.Future
 
 /**
@@ -30,7 +32,7 @@ trait SchemaProvider[Schema: CanAdd] {
    *
    * @return A future containing the schema for the data produced by Arcane.
    */
-  def getSchema: Future[SchemaType]
+  def getSchema: Task[SchemaType]
 
   /**
    * Gets an empty schema.

--- a/src/main/scala/services/cdm/CdmSchemaProvider.scala
+++ b/src/main/scala/services/cdm/CdmSchemaProvider.scala
@@ -4,46 +4,50 @@ package services.cdm
 import models.ArcaneSchema
 import models.cdm.{SimpleCdmEntity, SimpleCdmModel, given_Conversion_SimpleCdmEntity_ArcaneSchema}
 import services.base.SchemaProvider
-import services.cdm.CdmTableSettings
 import services.mssql.given_CanAdd_ArcaneSchema
+import services.storage.models.azure.AdlsStoragePath
 import services.storage.services.AzureBlobStorageReader
 
+import zio.stream.ZStream
 import zio.{Task, ZIO, ZLayer}
 
-import scala.concurrent.Future
+import java.io.IOException
 
 /**
  * A provider of a schema for a data produced by Microsoft Synapse Link.
  *
  * @param azureBlobStorageReader The reader for the Azure Blob Storage.
- * @param tableLocation The location of the table.
- * @param tableName The name of the table.
+ * @param tableLocation          The location of the table.
+ * @param tableName              The name of the table.
  */
 class CdmSchemaProvider(azureBlobStorageReader: AzureBlobStorageReader, tableLocation: String, tableName: String)
   extends SchemaProvider[ArcaneSchema]:
 
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
-
+  /**
+   * @inheritdoc
+   */
   override lazy val getSchema: Task[SchemaType] = getEntity.map(toArcaneSchema)
 
-  def getEntity: Task[SimpleCdmEntity] =
-    SimpleCdmModel(tableLocation, azureBlobStorageReader).flatMap(_.entities.find(_.name == tableName) match
-      case None => ZIO.fail(new Exception(s"Table $tableName not found in model $tableLocation"))
-      case Some(entity) => ZIO.succeed(entity)
-    )
+  private def getEntity: Task[SimpleCdmEntity] =
+    for modelPath <- ZIO.fromTry(AdlsStoragePath(tableLocation).map(_ + "model.json"))
+        reader = ZIO.fromAutoCloseable(azureBlobStorageReader.streamBlobContent(modelPath)).refineToOrDie[IOException]
+        stream = ZStream.fromReaderScoped(reader)
+        json <- stream.runCollect.map(_.mkString)
+        model = SimpleCdmModel(json)
+    yield model.entities.find(_.name == tableName).getOrElse(throw new Exception(s"Table $tableName not found in model $tableLocation"))
 
   override def empty: SchemaType = ArcaneSchema.empty()
-  
+
   private def toArcaneSchema(simpleCdmModel: SimpleCdmEntity): ArcaneSchema = simpleCdmModel
 
 object CdmSchemaProvider:
-  
+
   private type Environment = AzureBlobStorageReader & CdmTableSettings
-  
-  val layer: ZLayer[Environment, Nothing, CdmSchemaProvider] = 
-      ZLayer {
-        for
-          context <- ZIO.service[CdmTableSettings]
-          settings <- ZIO.service[AzureBlobStorageReader]
-        yield CdmSchemaProvider(settings, context.rootPath, context.name)
-      }
+
+  val layer: ZLayer[Environment, Nothing, CdmSchemaProvider] =
+    ZLayer {
+      for
+        context <- ZIO.service[CdmTableSettings]
+        settings <- ZIO.service[AzureBlobStorageReader]
+      yield CdmSchemaProvider(settings, context.rootPath, context.name)
+    }

--- a/src/main/scala/services/cdm/CdmSchemaProvider.scala
+++ b/src/main/scala/services/cdm/CdmSchemaProvider.scala
@@ -1,0 +1,49 @@
+package com.sneaksanddata.arcane.framework
+package services.cdm
+
+import models.ArcaneSchema
+import models.cdm.{SimpleCdmEntity, SimpleCdmModel, given_Conversion_SimpleCdmEntity_ArcaneSchema}
+import services.base.SchemaProvider
+import services.cdm.CdmTableSettings
+import services.mssql.given_CanAdd_ArcaneSchema
+import services.storage.services.AzureBlobStorageReader
+
+import zio.{Task, ZIO, ZLayer}
+
+import scala.concurrent.Future
+
+/**
+ * A provider of a schema for a data produced by Microsoft Synapse Link.
+ *
+ * @param azureBlobStorageReader The reader for the Azure Blob Storage.
+ * @param tableLocation The location of the table.
+ * @param tableName The name of the table.
+ */
+class CdmSchemaProvider(azureBlobStorageReader: AzureBlobStorageReader, tableLocation: String, tableName: String)
+  extends SchemaProvider[ArcaneSchema]:
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  override lazy val getSchema: Task[SchemaType] = getEntity.map(toArcaneSchema)
+
+  def getEntity: Task[SimpleCdmEntity] =
+    SimpleCdmModel(tableLocation, azureBlobStorageReader).flatMap(_.entities.find(_.name == tableName) match
+      case None => ZIO.fail(new Exception(s"Table $tableName not found in model $tableLocation"))
+      case Some(entity) => ZIO.succeed(entity)
+    )
+
+  override def empty: SchemaType = ArcaneSchema.empty()
+  
+  private def toArcaneSchema(simpleCdmModel: SimpleCdmEntity): ArcaneSchema = simpleCdmModel
+
+object CdmSchemaProvider:
+  
+  private type Environment = AzureBlobStorageReader & CdmTableSettings
+  
+  val layer: ZLayer[Environment, Nothing, CdmSchemaProvider] = 
+      ZLayer {
+        for
+          context <- ZIO.service[CdmTableSettings]
+          settings <- ZIO.service[AzureBlobStorageReader]
+        yield CdmSchemaProvider(settings, context.rootPath, context.name)
+      }

--- a/src/main/scala/services/cdm/SourceCleanupRequest.scala
+++ b/src/main/scala/services/cdm/SourceCleanupRequest.scala
@@ -1,0 +1,24 @@
+package com.sneaksanddata.arcane.framework
+package services.cdm
+
+import services.storage.models.azure.AdlsStoragePath
+
+/**
+ * A request to clean up the source.
+ * @param prefix The prefix of the source to clean up.
+ */
+case class SourceCleanupRequest(prefix: AdlsStoragePath)
+
+/**
+ * The result of a source cleanup.
+ * @param blobName The name of the blob.
+ * @param deleteMarker The name of the delete marker.
+ */
+case class SourceCleanupResult(blobName: AdlsStoragePath, deleteMarker: AdlsStoragePath)
+
+/**
+ * The result of a source deletion.
+ * @param blobName The name of the blob.
+ * @param succeed True if the deletion succeeded, false otherwise.
+ */
+case class SourceDeletionResult(blobName: AdlsStoragePath, succeed: Boolean)

--- a/src/main/scala/services/mssql/MsSqlConnection.scala
+++ b/src/main/scala/services/mssql/MsSqlConnection.scala
@@ -10,7 +10,7 @@ import services.mssql.base.{CanPeekHead, QueryResult}
 import services.mssql.query.{LazyQueryResult, QueryRunner, ScalarQueryResult}
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver
-import zio.{ZIO, ZLayer}
+import zio.{Task, ZIO, ZLayer}
 
 import java.sql.ResultSet
 import java.time.Duration
@@ -132,7 +132,7 @@ class MsSqlConnection(val connectionOptions: ConnectionOptions) extends AutoClos
    *
    * @return A future containing the schema for the data produced by Arcane.
    */
-  override lazy val getSchema: Future[this.SchemaType] = readSchemaFromSource
+  override lazy val getSchema: Task[this.SchemaType] = ZIO.fromFuture( implicit ec => readSchemaFromSource)
 
   /**
    * Gets the schema for the data produced by Arcane.

--- a/src/main/scala/services/streaming/consumers/IcebergBackfillConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergBackfillConsumer.scala
@@ -51,13 +51,13 @@ class IcebergBackfillConsumer(streamContext: StreamContext,
 
   private def createTable(rows: Chunk[DataRow], name: String): ZIO[Any, Throwable, Boolean] =
     for
-      arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
+      arcaneSchema <- schemaProvider.getSchema
       table <- ZIO.fromFuture(implicit ec => catalogWriter.write(rows, name, arcaneSchema))
     yield true
     
   private def writeWithWriter(rows: Chunk[DataRow], name: String): ZIO[Any, Throwable, Boolean] =
     for
-      arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
+      arcaneSchema <- schemaProvider.getSchema
       table <- ZIO.fromFuture(implicit ec => catalogWriter.append(rows, name, arcaneSchema))
     yield true
 

--- a/src/main/scala/services/streaming/consumers/IcebergStreamingConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergStreamingConsumer.scala
@@ -65,7 +65,7 @@ class IcebergStreamingConsumer(streamContext: StreamContext,
 
   private def writeWithWriter(rows: Chunk[DataRow], name: String): Task[StagedVersionedBatch] =
     for
-      arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
+      arcaneSchema <- schemaProvider.getSchema
       table <- ZIO.fromFuture(implicit ec => catalogWriter.write(rows, name, arcaneSchema))
     yield table.toStagedBatch(arcaneSchema, sinkSettings.sinkLocation, archiveTableSettings.fullName, tablePropertiesSettings)
 

--- a/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
+++ b/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
@@ -1,0 +1,32 @@
+package com.sneaksanddata.arcane.framework
+package services.cdm
+
+import services.storage.services.AzureBlobStorageReader
+
+import com.azure.storage.common.StorageSharedKeyCredential
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.should
+import zio.{Runtime, Unsafe}
+
+class CmdSchemaProviderTests extends AsyncFlatSpec with Matchers:
+  private val runtime = Runtime.default
+
+  private val endpoint = "http://localhost:10001/devstoreaccount1"
+  private val container = "cdm-e2e"
+  private val storageAccount = "devstoreaccount1"
+  private val accessKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+  private val tableName = "dimensionattributelevelvalue"
+
+  private val credential = StorageSharedKeyCredential(storageAccount, accessKey)
+  private val storageReader = AzureBlobStorageReader(storageAccount, endpoint, credential)
+
+  it should "be able to read schema from storage container" in {
+
+    val path = s"abfss://$container@$storageAccount.dfs.core.windows.net/"
+    val provider = CdmSchemaProvider(storageReader, path, tableName)
+
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(provider.getSchema)).map { result =>
+      result.length should be >= 1
+    }
+  }


### PR DESCRIPTION
Part of #29

Implemented:
- CdmSchemaProvider was moved from synapse link repository.
- Interface in the `SchemaProvider` trait was changed to use ZIO Task instead of future.
- The `apply` method of the `SimpleCdmModel` now returns the model instead of `Future[model]`

