### PR TITLE
Add frozen schema provider

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,10 +41,10 @@ lazy val root = (project in file("."))
     Test / logBuffered := false,
 
     // Framework dependencies
-    libraryDependencies += "dev.zio" %% "zio" % "2.1.6",
-    libraryDependencies += "dev.zio" %% "zio-streams" % "2.1.6",
+    libraryDependencies += "dev.zio" %% "zio" % "2.1.16",
+    libraryDependencies += "dev.zio" %% "zio-streams" % "2.1.16",
     libraryDependencies += "com.microsoft.sqlserver" % "mssql-jdbc" % "12.8.1.jre11",
-    libraryDependencies += "software.amazon.awssdk" % "s3" % "2.25.27", 
+    libraryDependencies += "software.amazon.awssdk" % "s3" % "2.25.27",
     libraryDependencies += "com.lihaoyi" %% "upickle" % "4.0.2",
 
     // https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-api
@@ -64,16 +64,21 @@ lazy val root = (project in file("."))
     // https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common
     libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "3.4.1",
     // https://mvnrepository.com/artifact/io.trino/trino-jdbc
-    libraryDependencies += "io.trino" % "trino-jdbc" % "465",
+    libraryDependencies += "io.trino" % "trino-jdbc" % "472",
 
     // Azure dependencies
     // https://mvnrepository.com/artifact/com.azure/azure-storage-blob
-    libraryDependencies += "com.azure" % "azure-storage-blob" % "12.29.0",
+    libraryDependencies += "com.azure" % "azure-storage-blob" % "12.29.1",
     // https://mvnrepository.com/artifact/com.azure/azure-identity
-    libraryDependencies += "com.azure" % "azure-identity" % "1.14.2",
+    libraryDependencies += "com.azure" % "azure-identity" % "1.15.3",
+    // Jackson pin
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.1",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.18.1",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-annotations" % "2.18.1",
+    libraryDependencies += "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.18.1",
 
 
-    // Test dependencies
+        // Test dependencies
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     libraryDependencies += "org.scalatest" %% "scalatest-flatspec" % "3.2.19" % Test,
     libraryDependencies += "org.scalatestplus" %% "easymock-5-3" % "3.2.19.0" % Test,
@@ -85,6 +90,6 @@ lazy val root = (project in file("."))
     
     // For DataDog
     libraryDependencies += "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.24.3",
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.16",
+    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.17",
     libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "8.0",
   )

--- a/populate-cdm-container.py
+++ b/populate-cdm-container.py
@@ -627,6 +627,208 @@ MODEL_JSON = """{
                         }
                       ],
                       "partitions": []
+                    },
+                    {
+                      "$type": "LocalEntity",
+                      "name": "dimensionattributelevel",
+                      "description": "dimensionattributelevel",
+                      "annotations": [
+                        {
+                          "name": "Athena:PartitionGranularity",
+                          "value": "Year"
+                        },
+                        {
+                          "name": "Athena:InitialSyncState",
+                          "value": "Completed"
+                        },
+                        {
+                          "name": "Athena:InitialSyncDataCompletedTime",
+                          "value": "1/1/2020 0:00:00 PM"
+                        }
+                      ],
+                      "attributes": [
+                        {
+                          "name": "Id",
+                          "dataType": "guid",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "SinkCreatedOn",
+                          "dataType": "dateTime",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "SinkModifiedOn",
+                          "dataType": "dateTime",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "sysdatastatecode",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "dimensionattributevalue",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "dimensionattributevaluegroup",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "displayvalue",
+                          "dataType": "string",
+                          "maxLength": 30,
+                          "cdm:traits": [
+                            {
+                              "traitReference": "is.constrained",
+                              "arguments": [
+                                {
+                                  "name": "maximumLength",
+                                  "value": 30
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "ordinal",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "backingrecorddataareaid",
+                          "dataType": "string",
+                          "maxLength": 4,
+                          "cdm:traits": [
+                            {
+                              "traitReference": "is.constrained",
+                              "arguments": [
+                                {
+                                  "name": "maximumLength",
+                                  "value": 4
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "modifieddatetime",
+                          "dataType": "dateTime",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "modifiedby",
+                          "dataType": "string",
+                          "maxLength": 20,
+                          "cdm:traits": [
+                            {
+                              "traitReference": "is.constrained",
+                              "arguments": [
+                                {
+                                  "name": "maximumLength",
+                                  "value": 20
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "modifiedtransactionid",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "createddatetime",
+                          "dataType": "dateTime",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "createdby",
+                          "dataType": "string",
+                          "maxLength": 20,
+                          "cdm:traits": [
+                            {
+                              "traitReference": "is.constrained",
+                              "arguments": [
+                                {
+                                  "name": "maximumLength",
+                                  "value": 20
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "createdtransactionid",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "dataareaid",
+                          "dataType": "string",
+                          "maxLength": 4,
+                          "cdm:traits": [
+                            {
+                              "traitReference": "is.constrained",
+                              "arguments": [
+                                {
+                                  "name": "maximumLength",
+                                  "value": 4
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "recversion",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "partition",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "sysrowversion",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "recid",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "tableid",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "versionnumber",
+                          "dataType": "int64",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "createdon",
+                          "dataType": "dateTimeOffset",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "modifiedon",
+                          "dataType": "dateTime",
+                          "maxLength": -1
+                        },
+                        {
+                          "name": "IsDelete",
+                          "dataType": "boolean",
+                          "maxLength": -1
+                        }
+                      ],
+                      "partitions": []
                     }
                   ]
                 }"""

--- a/src/main/scala/models/ArcaneSchema.scala
+++ b/src/main/scala/models/ArcaneSchema.scala
@@ -3,6 +3,8 @@ package models
 
 import models.ArcaneType.StringType
 
+import com.sneaksanddata.arcane.framework.services.base.CanAdd
+
 import scala.language.implicitConversions
 
 /**
@@ -107,3 +109,12 @@ object ArcaneSchema:
 
 given NamedCell[ArcaneSchemaField] with
   extension (field: ArcaneSchemaField) def name: String = field.name
+  
+/**
+ * Required typeclass implementation
+ */
+given CanAdd[ArcaneSchema] with
+  extension (a: ArcaneSchema) def addField(fieldName: String, fieldType: ArcaneType): ArcaneSchema = fieldName match
+    case MergeKeyField.name => a :+ MergeKeyField
+    case _ => a :+ Field(fieldName, fieldType)
+

--- a/src/main/scala/services/base/FrozenSchemaProvider.scala
+++ b/src/main/scala/services/base/FrozenSchemaProvider.scala
@@ -1,16 +1,35 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
-import zio.{IO, Promise, Task}
+import zio.{IO, Promise}
 
+/**
+ * A trait that represents a schema provider that holds a schema and not reads it from a storage on every call.
+ * @param schema The schema to provide.
+ * @param canAdd$T$0 The type class that provides the ability to add schemas.
+ * @tparam T The type of the schema.
+ */
 class FrozenSchemaProvider[T: CanAdd](schema: T):
 
+  /**
+   * The type of the schema.
+   */
   type SchemaType = T
 
+  /**
+   * The schema.
+   */
   lazy final val getSchema = schema
 
 
 object FrozenSchemaProvider:
+
+  /**
+   * Freezes the schema provider.
+   * @param inner The schema provider to freeze.
+   * @tparam T The type of the schema.
+   * @return A frozen schema provider.
+   */
   extension [T: CanAdd](inner: SchemaProvider[T]) def freeze: IO[Throwable, FrozenSchemaProvider[T]] = 
     for promise <- Promise.make[Throwable, T]
       fiber <- promise.complete(inner.getSchema).fork
@@ -18,4 +37,11 @@ object FrozenSchemaProvider:
       _ <- fiber.join
     yield  FrozenSchemaProvider[T](s)
 
+
+  /**
+   * Creates a frozen schema provider.
+   * @param inner The schema provider to freeze.
+   * @tparam T The type of the schema.
+   * @return A frozen schema provider instance.
+   */
   def apply[T: CanAdd](inner: T): FrozenSchemaProvider[T] = new FrozenSchemaProvider[T](inner)

--- a/src/main/scala/services/base/FrozenSchemaProvider.scala
+++ b/src/main/scala/services/base/FrozenSchemaProvider.scala
@@ -1,0 +1,21 @@
+package com.sneaksanddata.arcane.framework
+package services.base
+
+import zio.{IO, Promise, Task}
+
+class FrozenSchemaProvider[T: CanAdd](schema: T):
+
+  type SchemaType = T
+
+  lazy final val getSchema = schema
+
+
+object FrozenSchemaProvider:
+  extension [T: CanAdd](inner: SchemaProvider[T]) def freeze: IO[Throwable, FrozenSchemaProvider[T]] = 
+    for promise <- Promise.make[Throwable, T]
+      fiber <- promise.complete(inner.getSchema).fork
+      s <- promise.await
+      _ <- fiber.join
+    yield  FrozenSchemaProvider[T](s)
+
+  def apply[T: CanAdd](inner: T): FrozenSchemaProvider[T] = new FrozenSchemaProvider[T](inner)

--- a/src/main/scala/services/cdm/CdmSchemaProvider.scala
+++ b/src/main/scala/services/cdm/CdmSchemaProvider.scala
@@ -3,8 +3,8 @@ package services.cdm
 
 import models.ArcaneSchema
 import models.cdm.{SimpleCdmEntity, SimpleCdmModel, given_Conversion_SimpleCdmEntity_ArcaneSchema}
+import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
 import services.base.SchemaProvider
-import services.mssql.given_CanAdd_ArcaneSchema
 import services.storage.models.azure.AdlsStoragePath
 import services.storage.services.AzureBlobStorageReader
 
@@ -21,8 +21,7 @@ import java.io.IOException
  * @param tableLocation          The location of the table.
  * @param tableName              The name of the table.
  */
-class CdmSchemaProvider(azureBlobStorageReader: BlobStorageReader[AdlsStoragePath], tableLocation: String, tableName: String)
-  extends SchemaProvider[ArcaneSchema]:
+class CdmSchemaProvider(azureBlobStorageReader: BlobStorageReader[AdlsStoragePath], tableLocation: String, tableName: String) extends SchemaProvider[ArcaneSchema]:
 
   /**
    * @inheritdoc

--- a/src/main/scala/services/cdm/CdmSchemaProvider.scala
+++ b/src/main/scala/services/cdm/CdmSchemaProvider.scala
@@ -28,6 +28,9 @@ class CdmSchemaProvider(azureBlobStorageReader: BlobStorageReader[AdlsStoragePat
    */
   override lazy val getSchema: Task[SchemaType] = getEntity.map(toArcaneSchema)
 
+  /**
+   * @inheritdoc
+   */
   private def getEntity: Task[SimpleCdmEntity] =
     for modelPath <- ZIO.fromTry(AdlsStoragePath(tableLocation).map(_ + "model.json"))
         reader = ZIO.fromAutoCloseable(azureBlobStorageReader.streamBlobContent(modelPath)).refineToOrDie[IOException]
@@ -36,8 +39,14 @@ class CdmSchemaProvider(azureBlobStorageReader: BlobStorageReader[AdlsStoragePat
         model = SimpleCdmModel(json)
     yield model.entities.find(_.name == tableName).getOrElse(throw new Exception(s"Table $tableName not found in model $tableLocation"))
 
+  /**
+   * @inheritdoc
+   */
   override def empty: SchemaType = ArcaneSchema.empty()
 
+  /**
+   * @inheritdoc
+   */
   private def toArcaneSchema(simpleCdmModel: SimpleCdmEntity): ArcaneSchema = simpleCdmModel
 
 object CdmSchemaProvider:

--- a/src/main/scala/services/cdm/CdmTableStream.scala
+++ b/src/main/scala/services/cdm/CdmTableStream.scala
@@ -4,7 +4,7 @@ package services.cdm
 import logging.ZIOLogAnnotations.*
 import models.cdm.given_Conversion_String_ArcaneSchema_DataRow
 import models.{ArcaneSchema, DataRow}
-import services.base.SchemaProvider
+import services.base.{FrozenSchemaProvider, SchemaProvider}
 import services.cdm.BufferedReaderExtensions.streamMultilineCsv
 import services.storage.base.BlobStorageReader
 import services.storage.models.azure.AdlsStoragePath
@@ -22,7 +22,7 @@ given MetadataEnrichedRowStreamElement[SynapseLinkStreamElement] with
   extension (a: SynapseLinkStreamElement) def toDataRow: DataRow = a.asInstanceOf[DataRow]
   extension (a: DataRow) def fromDataRow: SynapseLinkStreamElement = a
 
-case class MetadataEnrichedReader(javaStream: BufferedReader, filePath: AdlsStoragePath, schemaProvider: SchemaProvider[ArcaneSchema])
+case class MetadataEnrichedReader(javaStream: BufferedReader, filePath: AdlsStoragePath, schemaProvider: FrozenSchemaProvider[ArcaneSchema])
 
 case class SchemaEnrichedContent[TContent](content: TContent, schema: ArcaneSchema)
 
@@ -44,7 +44,7 @@ class MicrosoftSynapseLinkDataProvider(fileNameStreamSource: TableFilesStreamSou
     ZStream.acquireReleaseWith(ZIO.attempt(mer.javaStream))(javaStream => ZIO.succeed(javaStream.close()))
       .flatMap(javaReader => javaReader.streamMultilineCsv)
       .map(_.replace("\n", ""))
-      .mapZIO(content => mer.schemaProvider.getSchema.map(schema => SchemaEnrichedContent(content, schema)))
+      .map(content => SchemaEnrichedContent(content, mer.schemaProvider.getSchema))
       .mapZIO(sec => ZIO.attempt(implicitly[DataRow](sec.content, sec.schema)))
       .mapError(e => new IOException(s"Failed to parse CSV content: ${e.getMessage} from file: ${mer.filePath} with", e))
       .concat(ZStream.succeed(SourceCleanupRequest(mer.filePath)))

--- a/src/main/scala/services/merging/JdbcMergeServiceClient.scala
+++ b/src/main/scala/services/merging/JdbcMergeServiceClient.scala
@@ -19,7 +19,7 @@ import services.merging.models.given_SqlExpressionConvertable_JdbcOrphanFilesExp
 import services.lakehouse.SchemaConversions
 import services.merging.JdbcMergeServiceClient.{generateAlterTableSQL, readStrings}
 import utils.SqlUtils.readArcaneSchema
-import services.mssql.given_CanAdd_ArcaneSchema
+import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
 
 import com.sneaksanddata.arcane.framework.models.app.StreamContext
 import com.sneaksanddata.arcane.framework.models.settings.{BackfillSettings, TablePropertiesSettings, TargetTableSettings}

--- a/src/main/scala/services/mssql/MsSqlConnection.scala
+++ b/src/main/scala/services/mssql/MsSqlConnection.scala
@@ -9,6 +9,8 @@ import services.mssql.QueryProvider.{getBackfillQuery, getChangesQuery, getSchem
 import services.mssql.base.{CanPeekHead, QueryResult}
 import services.mssql.query.{LazyQueryResult, QueryRunner, ScalarQueryResult}
 
+import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
+
 import com.microsoft.sqlserver.jdbc.SQLServerDriver
 import zio.{Task, ZIO, ZLayer}
 
@@ -50,14 +52,6 @@ case class ConnectionOptions(connectionUrl: String,
                              schemaName: String,
                              tableName: String,
                              partitionExpression: Option[String])
-
-/**
- * Required typeclass implementation
- */
-given CanAdd[ArcaneSchema] with
-  extension (a: ArcaneSchema) def addField(fieldName: String, fieldType: ArcaneType): ArcaneSchema = fieldName match
-    case MergeKeyField.name => a :+ MergeKeyField
-    case _ => a :+ Field(fieldName, fieldType)
 
 /**
  * Represents a connection to a Microsoft SQL Server database.

--- a/src/test/scala/services/cdm/AzureBlobStorageReaderExtensionsTests.scala
+++ b/src/test/scala/services/cdm/AzureBlobStorageReaderExtensionsTests.scala
@@ -99,7 +99,7 @@ class AzureBlobStorageReaderExtensionsTests extends AsyncFlatSpec with Matchers:
     val path = AdlsStoragePath(s"abfss://$container@$storageAccount.dfs.core.windows.net/").get
     val startDate = OffsetDateTime.now().minus(Duration.ofHours(12))
 
-    val stream = storageReader.streamTableContent(path, startDate, OffsetDateTime.now(), tableName).mapZIO(r => r.schemaProvider.getSchema).runCollect
+    val stream = storageReader.streamTableContent(path, startDate, OffsetDateTime.now(), tableName).map(r => r.schemaProvider.getSchema).runCollect
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(stream)).map { result =>
       // Check that all schemas are the same for this table
       result forall(_ == result.head) should be(true)

--- a/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
+++ b/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
@@ -1,15 +1,24 @@
 package com.sneaksanddata.arcane.framework
 package services.cdm
 
+import services.base.FrozenSchemaProvider.freeze
+import services.storage.base.BlobStorageReader
+import services.storage.models.azure.AdlsStoragePath
 import services.storage.services.AzureBlobStorageReader
 
 import com.azure.storage.common.StorageSharedKeyCredential
+import org.easymock.EasyMock.{replay, verify}
+import org.easymock.{EasyMock, IAnswer}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.should
+import org.scalatestplus.easymock.EasyMockSugar
+import org.scalatestplus.easymock.EasyMockSugar.{expecting, mock}
+import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
+import com.sneaksanddata.arcane.framework.services.base.FrozenSchemaProvider.freeze
 import zio.{Runtime, Unsafe}
 
-class CmdSchemaProviderTests extends AsyncFlatSpec with Matchers:
+class CmdSchemaProviderTests extends AsyncFlatSpec with Matchers with EasyMockSugar:
   private val runtime = Runtime.default
 
   private val endpoint = "http://localhost:10001/devstoreaccount1"
@@ -28,5 +37,46 @@ class CmdSchemaProviderTests extends AsyncFlatSpec with Matchers:
 
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(provider.getSchema)).map { result =>
       result.length should be >= 1
+    }
+  }
+
+  "CdmSchemaProvider" should "read the schema every time" in {
+    val path = s"abfss://$container@$storageAccount.dfs.core.windows.net/"
+    val storageReaderMock = mock[BlobStorageReader[AdlsStoragePath]]
+    expecting {
+      storageReaderMock.streamBlobContent(AdlsStoragePath("devstoreaccount1","cdm-e2e",s"model.json")).andAnswer(() => {
+        val arg = EasyMock.getCurrentArgument[AdlsStoragePath](0)
+        storageReader.streamBlobContent(arg)
+      })
+      .times(5)
+    }
+    replay(storageReaderMock)
+    val provider = CdmSchemaProvider(storageReaderMock, path, tableName)
+
+    val task = provider.getSchema *> provider.getSchema *> provider.getSchema *> provider.getSchema *> provider.getSchema
+
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(task)).map { result =>
+        noException should be thrownBy verify(storageReaderMock)
+    }
+  }
+
+  "FrozenSchemaProvider" should "NOT read the schema every time" in {
+    val path = s"abfss://$container@$storageAccount.dfs.core.windows.net/"
+    val storageReaderMock = mock[BlobStorageReader[AdlsStoragePath]]
+    expecting {
+      storageReaderMock.streamBlobContent(AdlsStoragePath("devstoreaccount1", "cdm-e2e", s"model.json")).andAnswer(() => {
+          val arg = EasyMock.getCurrentArgument[AdlsStoragePath](0)
+          storageReader.streamBlobContent(arg)
+        })
+        .once()
+    }
+    replay(storageReaderMock)
+    val task = CdmSchemaProvider(storageReaderMock, path, tableName).freeze.map(provider =>
+      List.unfold(0, provider.getSchema, (i: Int) => if (i < 5) Some((i + 1, provider.getSchema)) else None)
+    )
+
+
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(task)).map { result =>
+      noException should be thrownBy verify(storageReaderMock)
     }
   }

--- a/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
+++ b/src/test/scala/services/cdm/CmdSchemaProviderTests.scala
@@ -81,25 +81,3 @@ class CmdSchemaProviderTests extends AsyncFlatSpec with Matchers with EasyMockSu
       noException should be thrownBy verify(storageReaderMock)
     }
   }
-
-  "FrozenSchemaProvider" should "NOT read the schema every time" in {
-    val path = s"abfss://$container@$storageAccount.dfs.core.windows.net/"
-    val storageReaderMock = mock[BlobStorageReader[AdlsStoragePath]]
-    expecting {
-      storageReaderMock.streamBlobContent(AdlsStoragePath("devstoreaccount1", "cdm-e2e", s"model.json")).andAnswer(() => {
-          val arg = EasyMock.getCurrentArgument[AdlsStoragePath](0)
-          storageReader.streamBlobContent(arg)
-        })
-        .once()
-    }
-    replay(storageReaderMock)
-
-    val task = CdmSchemaProvider(storageReaderMock, path, tableName).freeze.map(provider =>
-      List.unfold(0, provider.getSchema, (i: Int) => if (i < 5) Some((i + 1, provider.getSchema)) else None)
-    )
-
-
-    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(task)).map { result =>
-      noException should be thrownBy verify(storageReaderMock)
-    }
-  }


### PR DESCRIPTION
This is a permanent fix for https://github.com/SneaksAndData/arcane-stream-microsoft-synapse-link/pull/92

## Implemented:
- Added the `FrozenSchemaProvider` trait that should be used in every case where we need to cache schema for multiple calls.