### PR TITLE
Generalize the StreamingGraphBuilder

### DIFF
--- a/src/main/scala/models/DataCell.scala
+++ b/src/main/scala/models/DataCell.scala
@@ -1,6 +1,8 @@
 package com.sneaksanddata.arcane.framework
 package models
 
+import services.streaming.base.MetadataEnrichedRowStreamElement
+
 /**
  * Represents a row of data.
  */
@@ -33,3 +35,8 @@ object DataCell:
 
 given NamedCell[DataCell] with
   extension (field: DataCell) def name: String = field.name
+  
+given MetadataEnrichedRowStreamElement[DataRow] with
+  extension (a: DataRow) def isDataRow: Boolean = a.isInstanceOf[DataRow]
+  extension (a: DataRow) def toDataRow: DataRow = a
+  extension (a: DataRow) def fromDataRow: DataRow  = a

--- a/src/main/scala/services/app/GenericStreamRunnerService.scala
+++ b/src/main/scala/services/app/GenericStreamRunnerService.scala
@@ -27,7 +27,7 @@ object GenericStreamRunnerService:
     def apply(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService): GenericStreamRunnerService =
       new GenericStreamRunnerService(builder, lifetimeService)
 
-    val layer: ZLayer[Environment, Nothing, StreamRunnerService] =
+    val layer: ZLayer[Environment, Nothing, GenericStreamRunnerService] =
       ZLayer{
         for
           lifetimeService <- ZIO.service[StreamLifetimeService]

--- a/src/main/scala/services/app/GenericStreamRunnerService.scala
+++ b/src/main/scala/services/app/GenericStreamRunnerService.scala
@@ -1,0 +1,36 @@
+package com.sneaksanddata.arcane.framework
+package services.app
+
+import logging.ZIOLogAnnotations.zlog
+import services.app.base.{StreamLifetimeService, StreamRunnerService}
+import services.streaming.base.{MetadataEnrichedRowStreamElement, StreamingGraphBuilder}
+
+import zio.stream.{ZPipeline, ZSink}
+import zio.{Tag, ZIO, ZLayer}
+
+class GenericStreamRunnerService(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService)
+  extends StreamRunnerService:
+
+  def run: ZIO[Any, Throwable, Unit] =
+    lifetimeService.start()
+    builder.produce.via(streamLifetimeGuard).run(logResults)
+
+
+  private def streamLifetimeGuard = ZPipeline.takeUntil(_ => lifetimeService.cancelled)
+
+  private def logResults = ZSink.foreach(result => zlog(s"Processing completed: $result"))
+
+object GenericStreamRunnerService:
+
+    type Environment = StreamLifetimeService & StreamingGraphBuilder
+
+    def apply(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService): GenericStreamRunnerService =
+      new GenericStreamRunnerService(builder, lifetimeService)
+
+    val layer: ZLayer[Environment, Nothing, StreamRunnerService] =
+      ZLayer{
+        for
+          lifetimeService <- ZIO.service[StreamLifetimeService]
+          builder <- ZIO.service[StreamingGraphBuilder]
+        yield GenericStreamRunnerService(builder, lifetimeService)
+      }

--- a/src/main/scala/services/app/GenericStreamRunnerService.scala
+++ b/src/main/scala/services/app/GenericStreamRunnerService.scala
@@ -8,29 +8,60 @@ import services.streaming.base.{MetadataEnrichedRowStreamElement, StreamingGraph
 import zio.stream.{ZPipeline, ZSink}
 import zio.{Tag, ZIO, ZLayer}
 
-class GenericStreamRunnerService(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService)
-  extends StreamRunnerService:
+/**
+ * A service that can be used to run a stream.
+ *
+ * @param builder The stream graph builder.
+ * @param lifetimeService The stream lifetime service.
+ */
+class GenericStreamRunnerService(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService) extends StreamRunnerService:
 
+  /**
+   * Runs the stream.
+   *
+   * @return A ZIO effect that represents the stream.
+   */
   def run: ZIO[Any, Throwable, Unit] =
     lifetimeService.start()
     builder.produce.via(streamLifetimeGuard).run(logResults)
 
-
+  /**
+   * The stage that completes the stream until the lifetime service is cancelled.
+   */
   private def streamLifetimeGuard = ZPipeline.takeUntil(_ => lifetimeService.cancelled)
 
+  /**
+   * Logs the results of the stream.
+   */
   private def logResults = ZSink.foreach(result => zlog(s"Processing completed: $result"))
 
+/**
+ * The companion object for the StreamRunnerServiceImpl class.
+ */
 object GenericStreamRunnerService:
 
-    type Environment = StreamLifetimeService & StreamingGraphBuilder
+  /**
+   * The required environment for the GenericStreamRunnerService.
+   */
+  type Environment = StreamLifetimeService & StreamingGraphBuilder
 
-    def apply(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService): GenericStreamRunnerService =
-      new GenericStreamRunnerService(builder, lifetimeService)
+  /**
+   * Creates a new instance of the GenericStreamRunnerService class.
+   *
+   * @param builder The stream graph builder.
+   * @param lifetimeService The stream lifetime service.
+   * @return A new instance of the GenericStreamRunnerService class.
+   */
+  def apply(builder: StreamingGraphBuilder, lifetimeService: StreamLifetimeService): GenericStreamRunnerService =
+    new GenericStreamRunnerService(builder, lifetimeService)
 
-    val layer: ZLayer[Environment, Nothing, GenericStreamRunnerService] =
-      ZLayer{
-        for
-          lifetimeService <- ZIO.service[StreamLifetimeService]
-          builder <- ZIO.service[StreamingGraphBuilder]
-        yield GenericStreamRunnerService(builder, lifetimeService)
-      }
+  /**
+   * The ZLayer for the GenericStreamRunnerService.
+   */
+  val layer: ZLayer[Environment, Nothing, StreamRunnerService] =
+    ZLayer{
+      for
+        lifetimeService <- ZIO.service[StreamLifetimeService]
+        builder <- ZIO.service[StreamingGraphBuilder]
+      yield GenericStreamRunnerService(builder, lifetimeService)
+    }

--- a/src/main/scala/services/cdm/CdmTableStream.scala
+++ b/src/main/scala/services/cdm/CdmTableStream.scala
@@ -27,9 +27,11 @@ case class MetadataEnrichedReader(javaStream: BufferedReader, filePath: AdlsStor
 case class SchemaEnrichedContent[TContent](content: TContent, schema: ArcaneSchema)
 
 class MicrosoftSynapseLinkDataProvider(fileNameStreamSource: TableFilesStreamSource, reader: BlobStorageReader[AdlsStoragePath], rootPath: AdlsStoragePath) //(name: String, storagePath: AdlsStoragePath, azureBlogStorageReader: AzureBlobStorageReader, reader: AzureBlobStorageReader, streamContext: StreamContext)
-  extends StreamDataProvider[SynapseLinkStreamElement]:
+  extends StreamDataProvider:
 
-  override def stream: ZStream[Any, Throwable, SynapseLinkStreamElement]  = fileNameStreamSource
+  override type StreamElementType = SynapseLinkStreamElement
+
+  override def stream: ZStream[Any, Throwable, StreamElementType]  = fileNameStreamSource
     .lookBackStream
     .concat(fileNameStreamSource.changeCaptureStream)
     .mapZIO(openContentReader)

--- a/src/main/scala/services/filters/FieldsFilteringService.scala
+++ b/src/main/scala/services/filters/FieldsFilteringService.scala
@@ -11,13 +11,24 @@ import zio.{ZIO, ZLayer}
  */
 class FieldsFilteringService(fieldSelectionRule: FieldSelectionRuleSettings):
 
+
   /**
    * Filters the fields of an ArcaneSchema.
    *
    * @param row The data to filter.
    * @return The filtered data/schema.
    */
-  def filter[T: NamedCell](row: Seq[T]): Seq[T] = fieldSelectionRule.rule match
+  def filter(row: DataRow): DataRow = fieldSelectionRule.rule match
+    case includeFields: FieldSelectionRule.IncludeFields => row.filter(entry => includeFields.fields.exists(f => entry.name.toLowerCase().equalsIgnoreCase(f)))
+    case excludeFields: FieldSelectionRule.ExcludeFields => row.filter(entry => !excludeFields.fields.exists(f => entry.name.toLowerCase().equalsIgnoreCase(f)))
+    case _ => row
+
+  /**
+   * Filters the fields of an ArcaneSchema.
+   * @param row The data to filter.
+   * @return The filtered data/schema.
+   */
+  def filter(row: ArcaneSchema): ArcaneSchema = fieldSelectionRule.rule match
     case includeFields: FieldSelectionRule.IncludeFields => row.filter(entry => includeFields.fields.exists(f => entry.name.toLowerCase().equalsIgnoreCase(f)))
     case excludeFields: FieldSelectionRule.ExcludeFields => row.filter(entry => !excludeFields.fields.exists(f => entry.name.toLowerCase().equalsIgnoreCase(f)))
     case _ => row

--- a/src/main/scala/services/streaming/base/GroupingTransformer.scala
+++ b/src/main/scala/services/streaming/base/GroupingTransformer.scala
@@ -1,6 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming.base
 
+import com.sneaksanddata.arcane.framework.models.DataRow
 import zio.Chunk
 import zio.stream.ZPipeline
 
@@ -9,9 +10,11 @@ import zio.stream.ZPipeline
   */
 trait GroupingTransformer:
   
+  type Element = DataRow|Any
+  
  /**
   * Processes the incoming data.
   *
   * @return ZPipeline (stream source for the stream graph).
   */
-  def process[Element: MetadataEnrichedRowStreamElement]: ZPipeline[Any, Throwable, Element, Chunk[Element]]
+  def process: ZPipeline[Any, Throwable, Element, Chunk[Element]]

--- a/src/main/scala/services/streaming/base/HookManager.scala
+++ b/src/main/scala/services/streaming/base/HookManager.scala
@@ -1,11 +1,14 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming.base
 
+import services.consumers.{MergeableBatch, StagedVersionedBatch}
 import services.streaming.processors.transformers.StagingProcessor
+
+import zio.Chunk
 
 trait HookManager:
   
   /**
    *  Enriches received staging batch with metadata and converts it to in-flight batch.
    **/
-  def toInFlightBatch: StagingProcessor#ToInFlightBatch
+  def onStagingTablesComplete(staged: Iterable[StagedVersionedBatch & MergeableBatch], index: Long, others: Chunk[Any]): StagingProcessor#OutgoingElement

--- a/src/main/scala/services/streaming/base/HookManager.scala
+++ b/src/main/scala/services/streaming/base/HookManager.scala
@@ -1,0 +1,11 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import services.streaming.processors.transformers.StagingProcessor
+
+trait HookManager:
+  
+  /**
+   *  Enriches received staging batch with metadata and converts it to in-flight batch.
+   **/
+  def toInFlightBatch: StagingProcessor#ToInFlightBatch

--- a/src/main/scala/services/streaming/base/HookManager.scala
+++ b/src/main/scala/services/streaming/base/HookManager.scala
@@ -6,6 +6,10 @@ import services.streaming.processors.transformers.StagingProcessor
 
 import zio.Chunk
 
+/**
+ * Manages hooks for the streaming process.
+ * Hooks can be used to enrich the data, log the results, etc. in future implementations.
+ */
 trait HookManager:
   
   /**

--- a/src/main/scala/services/streaming/base/MetadataEnrichedRowStreamElement.scala
+++ b/src/main/scala/services/streaming/base/MetadataEnrichedRowStreamElement.scala
@@ -7,7 +7,7 @@ import models.DataRow
  * A trait that represents a stream item that can contain stream of data rows interleaved with metadata of
  * any other kind.
  */
-trait MetadataEnrichedRowStreamElement[A]:
+trait MetadataEnrichedRowStreamElement[-A]:
   /**
    * Checks if the element is a data row.
    *
@@ -22,9 +22,11 @@ trait MetadataEnrichedRowStreamElement[A]:
    */
   extension (a: A) def toDataRow: DataRow
 
-  /**
-   * Converts the element from a data row.
-   *
-   * @return The element.
-   */
-  extension (a: DataRow) def fromDataRow: A
+//trait MetadataEnrichedRowStreamElement[-A]:
+//
+//  /**
+//   * Converts the element from a data row.
+//   *
+//   * @return The element.
+//   */
+//  extension (a: DataRow) def fromDataRow: A

--- a/src/main/scala/services/streaming/base/MetadataEnrichedRowStreamElement.scala
+++ b/src/main/scala/services/streaming/base/MetadataEnrichedRowStreamElement.scala
@@ -21,12 +21,3 @@ trait MetadataEnrichedRowStreamElement[-A]:
    * @return The data row.
    */
   extension (a: A) def toDataRow: DataRow
-
-//trait MetadataEnrichedRowStreamElement[-A]:
-//
-//  /**
-//   * Converts the element from a data row.
-//   *
-//   * @return The element.
-//   */
-//  extension (a: DataRow) def fromDataRow: A

--- a/src/main/scala/services/streaming/base/RowGroupTransformer.scala
+++ b/src/main/scala/services/streaming/base/RowGroupTransformer.scala
@@ -30,9 +30,11 @@ trait RowGroupTransformer:
   
   type ToInFlightBatch = (Iterable[StagedVersionedBatch & MergeableBatch], Long, Chunk[Any]) => OutgoingElement
   
+  type IncomingElement = DataRow|Any
+  
   /**
    * Processes the incoming data.
    *
    * @return ZPipeline (stream source for the stream graph).
    */
-  def process[IncomingElement: MetadataEnrichedRowStreamElement](toInFlightBatch: ToInFlightBatch): ZPipeline[Any, Throwable, Chunk[IncomingElement], OutgoingElement]
+  def process(toInFlightBatch: ToInFlightBatch): ZPipeline[Any, Throwable, Chunk[IncomingElement], OutgoingElement]

--- a/src/main/scala/services/streaming/base/RowProcessor.scala
+++ b/src/main/scala/services/streaming/base/RowProcessor.scala
@@ -9,10 +9,12 @@ import zio.stream.ZPipeline
   * A trait that represents a row processor.
  */
 trait RowProcessor:
+
+  type Element = DataRow|Any
   
   /**
    * Processes the incoming data.
    *
    * @return ZPipeline (stream source for the stream graph).
    */
-  def process[Element: MetadataEnrichedRowStreamElement]: ZPipeline[Any, Throwable, Element, Element]
+  def process: ZPipeline[Any, Throwable, Element, Element]

--- a/src/main/scala/services/streaming/base/StreamDataProvider.scala
+++ b/src/main/scala/services/streaming/base/StreamDataProvider.scala
@@ -1,11 +1,10 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming.base
 
-import zio.Task
 import zio.stream.ZStream
 
-import java.time.Duration
+trait StreamDataProvider:
 
-trait StreamDataProvider[StreamElementType: MetadataEnrichedRowStreamElement]:
-  
+  type StreamElementType
+
   def stream: ZStream[Any, Throwable, StreamElementType]

--- a/src/main/scala/services/streaming/base/StreamDataProvider.scala
+++ b/src/main/scala/services/streaming/base/StreamDataProvider.scala
@@ -3,8 +3,17 @@ package services.streaming.base
 
 import zio.stream.ZStream
 
+/**
+ * Provides data from the data source for Arcane stream.
+ */
 trait StreamDataProvider:
 
+  /**
+   * The type of the stream element.
+   */
   type StreamElementType
 
+  /**
+   * Returns the stream of elements.
+   */
   def stream: ZStream[Any, Throwable, StreamElementType]

--- a/src/main/scala/services/streaming/base/StreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/base/StreamingGraphBuilder.scala
@@ -1,12 +1,20 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming.base
 
-import services.streaming.processors.transformers.StagingProcessor
-
 import zio.stream.ZStream
 
+/**
+ * Provides the complete data stream for the streaming process including all the stages and services
+ * except the sink and lifetime service.
+ */
 trait StreamingGraphBuilder:
-  
+
+  /**
+   * The type of the processed batch.
+   */
   type ProcessedBatch
-  
+
+  /**
+   * Produces the stream of processed batches.
+   */
   def produce: ZStream[Any, Throwable, ProcessedBatch]

--- a/src/main/scala/services/streaming/base/StreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/base/StreamingGraphBuilder.scala
@@ -1,0 +1,12 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import services.streaming.processors.transformers.StagingProcessor
+
+import zio.stream.ZStream
+
+trait StreamingGraphBuilder:
+  
+  type ProcessedBatch
+  
+  def produce: ZStream[Any, Throwable, ProcessedBatch]

--- a/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
@@ -1,77 +1,77 @@
-//package com.sneaksanddata.arcane.framework
-//package services.streaming.graph_builders.base
-//
-//import models.{DataRow, given_MetadataEnrichedRowStreamElement_DataRow}
-//import services.app.base.StreamLifetimeService
-//import services.streaming.base.{DataRowProvider, HookManager, MetadataEnrichedRowStreamElement, StreamDataProvider, StreamingGraphBuilder}
-//import services.streaming.processors.GenericGroupingTransformer
-//import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
-//import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
-//
-//import zio.stream.ZStream
-//import zio.{Tag, ZIO, ZLayer}
-//
-//class GenericStreamingGraphBuilder(streamDataProvider: DataRowProvider,
-//                                   fieldFilteringProcessor: FieldFilteringTransformer,
-//                                   groupTransformer: GenericGroupingTransformer,
-//                                   stagingProcessor: StagingProcessor,
-//                                   mergeProcessor: MergeBatchProcessor,
-//                                   disposeBatchProcessor: DisposeBatchProcessor,
-//                                   hookManager: HookManager)
-//  extends StreamingGraphBuilder:
-//
-//  type ProcessedBatch = DisposeBatchProcessor#BatchType
-//
-//  override def produce: ZStream[Any, Throwable, ProcessedBatch] =
-//    streamDataProvider.stream
-//      .via(fieldFilteringProcessor.process)
-//      .via(groupTransformer.process)
-//      .via(stagingProcessor.process(hookManager.toInFlightBatch))
-//      .via(mergeProcessor.process)
-//      .via(disposeBatchProcessor.process)
-//
-//object GenericStreamingGraphBuilder:
-//
-//  type Environment = DataRowProvider
-//    & GenericGroupingTransformer
-//    & FieldFilteringTransformer
-//    & StagingProcessor
-//    & MergeBatchProcessor
-//    & DisposeBatchProcessor
-//    & StreamLifetimeService
-//    & HookManager
-//
-//
-//  def apply[T: MetadataEnrichedRowStreamElement: Tag](streamDataProvider: DataRowProvider,
-//                                                      fieldFilteringProcessor: FieldFilteringTransformer,
-//                                                      groupTransformer: GenericGroupingTransformer,
-//                                                      stagingProcessor: StagingProcessor,
-//                                                      mergeProcessor: MergeBatchProcessor,
-//                                                      disposeBatchProcessor: DisposeBatchProcessor,
-//                                                      hookManager: HookManager): GenericStreamingGraphBuilder =
-//    new GenericStreamingGraphBuilder(streamDataProvider,
-//      fieldFilteringProcessor,
-//      groupTransformer,
-//      stagingProcessor,
-//      mergeProcessor,
-//      disposeBatchProcessor,
-//      hookManager)
-//
-//  def layer: ZLayer[Environment, Nothing, GenericStreamingGraphBuilder] =
-//    ZLayer {
-//      for
-//        streamDataProvider <- ZIO.service[DataRowProvider]
-//        fieldFilteringProcessor <- ZIO.service[FieldFilteringTransformer]
-//        groupTransformer <- ZIO.service[GenericGroupingTransformer]
-//        stagingProcessor <- ZIO.service[StagingProcessor]
-//        mergeProcessor <- ZIO.service[MergeBatchProcessor]
-//        disposeBatchProcessor <- ZIO.service[DisposeBatchProcessor]
-//        hookManager <- ZIO.service[HookManager]
-//      yield GenericStreamingGraphBuilder(streamDataProvider,
-//        fieldFilteringProcessor,
-//        groupTransformer,
-//        stagingProcessor,
-//        mergeProcessor,
-//        disposeBatchProcessor,
-//        hookManager)
-//    }
+package com.sneaksanddata.arcane.framework
+package services.streaming.graph_builders.base
+
+import models.{DataRow, given_MetadataEnrichedRowStreamElement_DataRow}
+import services.app.base.StreamLifetimeService
+import services.streaming.base.{HookManager, MetadataEnrichedRowStreamElement, StreamDataProvider, StreamingGraphBuilder}
+import services.streaming.processors.GenericGroupingTransformer
+import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
+import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
+
+import zio.stream.ZStream
+import zio.{Tag, ZIO, ZLayer}
+
+class GenericStreamingGraphBuilder(streamDataProvider: StreamDataProvider,
+                                   fieldFilteringProcessor: FieldFilteringTransformer,
+                                   groupTransformer: GenericGroupingTransformer,
+                                   stagingProcessor: StagingProcessor,
+                                   mergeProcessor: MergeBatchProcessor,
+                                   disposeBatchProcessor: DisposeBatchProcessor,
+                                   hookManager: HookManager)
+  extends StreamingGraphBuilder:
+
+  type ProcessedBatch = DisposeBatchProcessor#BatchType
+
+  override def produce: ZStream[Any, Throwable, ProcessedBatch] =
+    streamDataProvider.stream
+      .via(fieldFilteringProcessor.process)
+      .via(groupTransformer.process)
+      .via(stagingProcessor.process(hookManager.toInFlightBatch))
+      .via(mergeProcessor.process)
+      .via(disposeBatchProcessor.process)
+
+object GenericStreamingGraphBuilder:
+
+  type Environment = StreamDataProvider
+    & GenericGroupingTransformer
+    & FieldFilteringTransformer
+    & StagingProcessor
+    & MergeBatchProcessor
+    & DisposeBatchProcessor
+    & StreamLifetimeService
+    & HookManager
+
+
+  def apply[T: MetadataEnrichedRowStreamElement: Tag](streamDataProvider: StreamDataProvider,
+                                                      fieldFilteringProcessor: FieldFilteringTransformer,
+                                                      groupTransformer: GenericGroupingTransformer,
+                                                      stagingProcessor: StagingProcessor,
+                                                      mergeProcessor: MergeBatchProcessor,
+                                                      disposeBatchProcessor: DisposeBatchProcessor,
+                                                      hookManager: HookManager): GenericStreamingGraphBuilder =
+    new GenericStreamingGraphBuilder(streamDataProvider,
+      fieldFilteringProcessor,
+      groupTransformer,
+      stagingProcessor,
+      mergeProcessor,
+      disposeBatchProcessor,
+      hookManager)
+
+  def layer: ZLayer[Environment, Nothing, GenericStreamingGraphBuilder] =
+    ZLayer {
+      for
+        streamDataProvider <- ZIO.service[StreamDataProvider]
+        fieldFilteringProcessor <- ZIO.service[FieldFilteringTransformer]
+        groupTransformer <- ZIO.service[GenericGroupingTransformer]
+        stagingProcessor <- ZIO.service[StagingProcessor]
+        mergeProcessor <- ZIO.service[MergeBatchProcessor]
+        disposeBatchProcessor <- ZIO.service[DisposeBatchProcessor]
+        hookManager <- ZIO.service[HookManager]
+      yield GenericStreamingGraphBuilder(streamDataProvider,
+        fieldFilteringProcessor,
+        groupTransformer,
+        stagingProcessor,
+        mergeProcessor,
+        disposeBatchProcessor,
+        hookManager)
+    }

--- a/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
@@ -26,7 +26,7 @@ class GenericStreamingGraphBuilder(streamDataProvider: StreamDataProvider,
     streamDataProvider.stream
       .via(fieldFilteringProcessor.process)
       .via(groupTransformer.process)
-      .via(stagingProcessor.process(hookManager.toInFlightBatch))
+      .via(stagingProcessor.process(hookManager.onStagingTablesComplete))
       .via(mergeProcessor.process)
       .via(disposeBatchProcessor.process)
 

--- a/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
@@ -1,0 +1,77 @@
+//package com.sneaksanddata.arcane.framework
+//package services.streaming.graph_builders.base
+//
+//import models.{DataRow, given_MetadataEnrichedRowStreamElement_DataRow}
+//import services.app.base.StreamLifetimeService
+//import services.streaming.base.{DataRowProvider, HookManager, MetadataEnrichedRowStreamElement, StreamDataProvider, StreamingGraphBuilder}
+//import services.streaming.processors.GenericGroupingTransformer
+//import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
+//import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
+//
+//import zio.stream.ZStream
+//import zio.{Tag, ZIO, ZLayer}
+//
+//class GenericStreamingGraphBuilder(streamDataProvider: DataRowProvider,
+//                                   fieldFilteringProcessor: FieldFilteringTransformer,
+//                                   groupTransformer: GenericGroupingTransformer,
+//                                   stagingProcessor: StagingProcessor,
+//                                   mergeProcessor: MergeBatchProcessor,
+//                                   disposeBatchProcessor: DisposeBatchProcessor,
+//                                   hookManager: HookManager)
+//  extends StreamingGraphBuilder:
+//
+//  type ProcessedBatch = DisposeBatchProcessor#BatchType
+//
+//  override def produce: ZStream[Any, Throwable, ProcessedBatch] =
+//    streamDataProvider.stream
+//      .via(fieldFilteringProcessor.process)
+//      .via(groupTransformer.process)
+//      .via(stagingProcessor.process(hookManager.toInFlightBatch))
+//      .via(mergeProcessor.process)
+//      .via(disposeBatchProcessor.process)
+//
+//object GenericStreamingGraphBuilder:
+//
+//  type Environment = DataRowProvider
+//    & GenericGroupingTransformer
+//    & FieldFilteringTransformer
+//    & StagingProcessor
+//    & MergeBatchProcessor
+//    & DisposeBatchProcessor
+//    & StreamLifetimeService
+//    & HookManager
+//
+//
+//  def apply[T: MetadataEnrichedRowStreamElement: Tag](streamDataProvider: DataRowProvider,
+//                                                      fieldFilteringProcessor: FieldFilteringTransformer,
+//                                                      groupTransformer: GenericGroupingTransformer,
+//                                                      stagingProcessor: StagingProcessor,
+//                                                      mergeProcessor: MergeBatchProcessor,
+//                                                      disposeBatchProcessor: DisposeBatchProcessor,
+//                                                      hookManager: HookManager): GenericStreamingGraphBuilder =
+//    new GenericStreamingGraphBuilder(streamDataProvider,
+//      fieldFilteringProcessor,
+//      groupTransformer,
+//      stagingProcessor,
+//      mergeProcessor,
+//      disposeBatchProcessor,
+//      hookManager)
+//
+//  def layer: ZLayer[Environment, Nothing, GenericStreamingGraphBuilder] =
+//    ZLayer {
+//      for
+//        streamDataProvider <- ZIO.service[DataRowProvider]
+//        fieldFilteringProcessor <- ZIO.service[FieldFilteringTransformer]
+//        groupTransformer <- ZIO.service[GenericGroupingTransformer]
+//        stagingProcessor <- ZIO.service[StagingProcessor]
+//        mergeProcessor <- ZIO.service[MergeBatchProcessor]
+//        disposeBatchProcessor <- ZIO.service[DisposeBatchProcessor]
+//        hookManager <- ZIO.service[HookManager]
+//      yield GenericStreamingGraphBuilder(streamDataProvider,
+//        fieldFilteringProcessor,
+//        groupTransformer,
+//        stagingProcessor,
+//        mergeProcessor,
+//        disposeBatchProcessor,
+//        hookManager)
+//    }

--- a/src/main/scala/services/streaming/processors/GenericGroupingTransformer.scala
+++ b/src/main/scala/services/streaming/processors/GenericGroupingTransformer.scala
@@ -18,11 +18,11 @@ class GenericGroupingTransformer(groupingSettings: GroupingSettings) extends Gro
   /**
    * @inheritdoc
    */
-  def process[Element: MetadataEnrichedRowStreamElement]: ZPipeline[Any, Throwable, Element, Chunk[Element]] = ZPipeline
+  def process: ZPipeline[Any, Throwable, Element, Chunk[Element]] = ZPipeline
     .groupedWithin(groupingSettings.rowsPerGroup, groupingSettings.groupingInterval)
     .mapZIO(logBatchSize)
 
-  private def logBatchSize[Element: MetadataEnrichedRowStreamElement](batch: Chunk[Element]): ZIO[Any, Nothing, Chunk[Element]] =
+  private def logBatchSize(batch: Chunk[Element]) =
     for _ <- zlog(s"Received batch with ${batch.size} rows from streaming source") yield batch
     
 /**

--- a/src/main/scala/services/streaming/processors/transformers/FieldFilteringTransformer.scala
+++ b/src/main/scala/services/streaming/processors/transformers/FieldFilteringTransformer.scala
@@ -15,12 +15,14 @@ import zio.{ZIO, ZLayer}
  */
 class FieldFilteringTransformer(fieldsFilteringService: FieldsFilteringService) extends RowProcessor:
 
+  type Element = DataRow|Any
+  
   /**
    * @inheritdoc
    */
-  override def process[Element: MetadataEnrichedRowStreamElement]: ZPipeline[Any, Throwable, Element, Element] = ZPipeline.map {
-    case row if row.isDataRow => fieldsFilteringService.filter[DataCell](row.toDataRow).asInstanceOf[DataRow].fromDataRow
-    case other if !other.isDataRow => other
+  override def process: ZPipeline[Any, Throwable, Element, Element] = ZPipeline.map {
+    case row: DataRow => fieldsFilteringService.filter(row).asInstanceOf[Element]
+    case other: Any => other
   }
 
 /**

--- a/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
+++ b/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
@@ -32,12 +32,14 @@ class StagingProcessor(stagingDataSettings: StagingDataSettings,
   private val retryPolicy = Schedule.exponential(Duration.ofSeconds(1)) && Schedule.recurs(10)
 
   type OutgoingElement = StagedBatchProcessor#BatchType
+  
+  type IncomingElement = DataRow|Any
 
-  override def process[IncomingElement: MetadataEnrichedRowStreamElement](toInFlightBatch: ToInFlightBatch): ZPipeline[Any, Throwable, Chunk[IncomingElement], OutgoingElement] =
+  override def process(toInFlightBatch: ToInFlightBatch): ZPipeline[Any, Throwable, Chunk[IncomingElement], OutgoingElement] =
     ZPipeline[Chunk[IncomingElement]]()
       .mapZIO(elements =>
-        val groupedBySchema = elements.withFilter(e => e.isDataRow).map(e => e.toDataRow).groupBy(row => row.schema)
-        val others = elements.filterNot(e => e.isDataRow)
+        val groupedBySchema = elements.withFilter(e => e.isInstanceOf[DataRow]).map(e => e.asInstanceOf[DataRow]).groupBy(row => row.schema)
+        val others = elements.filterNot(e => e.isInstanceOf[DataRow])
         val applyTasks = ZIO.foreach(groupedBySchema.keys)(schema => writeDataRows(groupedBySchema(schema), schema))
         applyTasks.map(batches => (batches, others))
       )

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -3,6 +3,7 @@ package services.streaming
 
 import models.{ArcaneType, DataCell, DataRow, MergeKeyField}
 import services.app.GenericStreamRunnerService
+import services.app.base.StreamRunnerService
 import services.base.{DisposeServiceClient, MergeServiceClient}
 import services.filters.FieldsFilteringService
 import services.lakehouse.base.CatalogWriter
@@ -75,7 +76,7 @@ class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with E
     }
     replay(catalogWriter, streamDataProvider, tableMock, hookManager)
 
-    val streamRunnerService = ZIO.service[GenericStreamRunnerService].provide(
+    val streamRunnerService = ZIO.service[StreamRunnerService].provide(
       // Real services
       GenericStreamRunnerService.layer,
       GenericStreamingGraphBuilder.layer,

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -1,0 +1,54 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming
+
+import com.sneaksanddata.arcane.framework.models.{ArcaneType, DataCell, DataRow, MergeKeyField}
+import com.sneaksanddata.arcane.framework.models.given_MetadataEnrichedRowStreamElement_DataRow
+import com.sneaksanddata.arcane.framework.services.app.GenericStreamRunnerService
+import com.sneaksanddata.arcane.framework.services.filters.FieldsFilteringService
+import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.base.GenericStreamingGraphBuilder
+import GenericStreamingGraphBuilder.Environment
+import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.DisposeBatchProcessor
+import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.MergeBatchProcessor
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.FieldFilteringTransformer.Environment
+import org.easymock.EasyMock.verify
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.should
+import org.scalatestplus.easymock.EasyMockSugar
+import zio.{Chunk, Runtime, Unsafe, ZIO, ZLayer}
+
+class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with EasyMockSugar:
+  private val runtime = Runtime.default
+
+  private val testInput: Chunk[DataRow] = Chunk.fromIterable(List(
+    List(DataCell("name", ArcaneType.StringType, "John Doe"), DataCell(MergeKeyField.name, MergeKeyField.fieldType, "1")),
+    List(DataCell("name", ArcaneType.StringType, "John"), DataCell("family_name", ArcaneType.StringType, "Doe"), DataCell(MergeKeyField.name, MergeKeyField.fieldType, "1")),
+  ))
+
+  val layer =
+    FieldsFilteringService.layer >>>
+    FieldFilteringTransformer.layer >>>
+    StagingProcessor.layer >>>
+    MergeBatchProcessor.layer >>>
+    DisposeBatchProcessor.layer
+    GenericStreamingGraphBuilder.layer >>>
+    GenericStreamRunnerService.layer
+
+  it should "run the stream" in {
+    // Arrange
+    val streamRunnerService = ZIO.service[GenericStreamRunnerService].provide(layer)
+    
+    
+    // Act
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(streamRunnerService)).map { result =>
+      // Assert
+      result should not be null
+    }
+
+//    // Act
+//    val result = runtime.unsafeRun(streamRunnerService.run)
+//
+//    // Assert
+//    result mustBe testInput
+  }

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -1,37 +1,83 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming
 
-import com.sneaksanddata.arcane.framework.models.{ArcaneType, DataCell, DataRow, MergeKeyField}
-import com.sneaksanddata.arcane.framework.models.given_MetadataEnrichedRowStreamElement_DataRow
-import com.sneaksanddata.arcane.framework.services.app.GenericStreamRunnerService
-import com.sneaksanddata.arcane.framework.services.filters.FieldsFilteringService
-import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.base.GenericStreamingGraphBuilder
-import com.sneaksanddata.arcane.framework.services.streaming.processors.GenericGroupingTransformer
-import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.DisposeBatchProcessor
-import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.MergeBatchProcessor
-import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
-import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.FieldFilteringTransformer.Environment
-import com.sneaksanddata.arcane.framework.utils.TestStreamLifetimeService
-import org.easymock.EasyMock.verify
+import models.{ArcaneType, DataCell, DataRow, MergeKeyField}
+import services.app.GenericStreamRunnerService
+import services.base.{DisposeServiceClient, MergeServiceClient}
+import services.filters.FieldsFilteringService
+import services.lakehouse.base.CatalogWriter
+import services.merging.JdbcTableManager
+import services.streaming.base.{HookManager, StreamDataProvider}
+import services.streaming.graph_builders.base.GenericStreamingGraphBuilder
+import services.streaming.processors.GenericGroupingTransformer
+import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
+import services.streaming.processors.transformers.FieldFilteringTransformer.Environment
+import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
+import services.streaming.processors.utils.TestIndexedStagedBatches
+import utils.*
+
+import org.apache.iceberg.rest.RESTCatalog
+import org.apache.iceberg.{Schema, Table}
+import org.easymock.EasyMock
+import org.easymock.EasyMock.{replay, verify}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.should
 import org.scalatestplus.easymock.EasyMockSugar
-import zio.{Chunk, Runtime, Unsafe, ZIO, ZLayer}
+import zio.stream.ZStream
+import zio.{Chunk, Runtime, Schedule, Unsafe, ZIO, ZLayer}
 
 class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with EasyMockSugar:
   private val runtime = Runtime.default
 
-  private val testInput: Chunk[DataRow] = Chunk.fromIterable(List(
+  private val testInput = List(
     List(DataCell("name", ArcaneType.StringType, "John Doe"), DataCell(MergeKeyField.name, MergeKeyField.fieldType, "1")),
     List(DataCell("name", ArcaneType.StringType, "John"), DataCell("family_name", ArcaneType.StringType, "Doe"), DataCell(MergeKeyField.name, MergeKeyField.fieldType, "1")),
-  ))
+  )
 
-  it should "run the stream" in {
+  it should "gracefully handle stream shutdown" in {
     // Arrange
+    val streamRepeatCount = 5
+
+    val disposeServiceClient = mock[DisposeServiceClient]
+    val mergeServiceClient = mock[MergeServiceClient]
+    val jdbcTableManager = mock[JdbcTableManager]
+    val hookManager = mock[HookManager]
+    val streamDataProvider = mock[StreamDataProvider]
+
+    val catalogWriter = mock[CatalogWriter[RESTCatalog, Table, Schema]]
+    val tableMock = mock[Table]
+
+    expecting {
+
+      // The table mock, does not verify anything
+      tableMock
+        .name()
+        .andReturn("database.namespace.name")
+        .anyTimes()
+
+      // The data provider mock provides an infinite stream of test input
+      streamDataProvider.stream.andReturn(ZStream.fromIterable(testInput).repeat(Schedule.forever))
+
+      // The catalogWriter.write method is called ``streamRepeatCount`` times
+      catalogWriter
+        .write(EasyMock.anyObject[Chunk[DataRow]], EasyMock.anyString(), EasyMock.anyObject())
+        .andReturn(ZIO.succeed(tableMock))
+        .times(streamRepeatCount)
+
+      // The hookManager.onStagingTablesComplete method is called ``streamRepeatCount`` times
+      // It produces the empty set of staged batches, so the rest  of the pipeline can continue
+      // but no further stages being invoked
+      hookManager
+        .onStagingTablesComplete(EasyMock.anyObject(), EasyMock.anyLong(), EasyMock.anyObject())
+        .andReturn(new TestIndexedStagedBatches(List.empty, 0))
+        .times(streamRepeatCount)
+    }
+    replay(catalogWriter, streamDataProvider, tableMock, hookManager)
+
     val streamRunnerService = ZIO.service[GenericStreamRunnerService].provide(
+      // Real services
       GenericStreamRunnerService.layer,
-      ZLayer.succeed(new TestStreamLifetimeService(5, identity)),
       GenericStreamingGraphBuilder.layer,
       GenericGroupingTransformer.layer,
       DisposeBatchProcessor.layer,
@@ -39,18 +85,28 @@ class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with E
       MergeBatchProcessor.layer,
       StagingProcessor.layer,
       FieldsFilteringService.layer,
+
+      // Settings
+      ZLayer.succeed(TestGroupingSettings),
+      ZLayer.succeed(TestStagingDataSettings),
+      ZLayer.succeed(TablePropertiesSettings),
+      ZLayer.succeed(TestTargetTableSettings),
+      ZLayer.succeed(TestIcebergCatalogSettings),
+      ZLayer.succeed(TestFieldSelectionRuleSettings),
+
+      // Mocks
+      ZLayer.succeed(catalogWriter),
+      ZLayer.succeed(new TestStreamLifetimeService(streamRepeatCount-1, identity)),
+      ZLayer.succeed(disposeServiceClient),
+      ZLayer.succeed(mergeServiceClient),
+      ZLayer.succeed(jdbcTableManager),
+      ZLayer.succeed(hookManager),
+      ZLayer.succeed(streamDataProvider)
     )
 
-
     // Act
-    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(streamRunnerService)).map { result =>
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(streamRunnerService.flatMap(_.run))).map { result =>
       // Assert
-      result should not be null
+      noException should be thrownBy verify(catalogWriter, streamDataProvider, tableMock, hookManager)
     }
-
-//    // Act
-//    val result = runtime.unsafeRun(streamRunnerService.run)
-//
-//    // Assert
-//    result mustBe testInput
   }

--- a/src/test/scala/utils/TestFieldSelectionRuleSettings.scala
+++ b/src/test/scala/utils/TestFieldSelectionRuleSettings.scala
@@ -1,0 +1,7 @@
+package com.sneaksanddata.arcane.framework
+package utils
+
+import models.settings.{FieldSelectionRule, FieldSelectionRuleSettings}
+
+object TestFieldSelectionRuleSettings extends FieldSelectionRuleSettings:
+  override val rule: FieldSelectionRule = FieldSelectionRule.AllFields

--- a/src/test/scala/utils/TestGroupingSettings.scala
+++ b/src/test/scala/utils/TestGroupingSettings.scala
@@ -5,4 +5,6 @@ import models.settings.GroupingSettings
 
 import java.time.Duration
 
-class TestGroupingSettings(val groupingInterval: Duration, val rowsPerGroup: Int) extends GroupingSettings
+object TestGroupingSettings extends GroupingSettings:
+  override val groupingInterval: Duration = Duration.ofMillis(1)
+  override val rowsPerGroup: Int = 1


### PR DESCRIPTION
Part of  #29

## Implemented:
- Generalized `StreamRunnerService` interface and corresponding class.
- Generalized `StreamingGraphBuilder` interface and corresponding class.
- Added unit tests.

## Additional changes
- Simplified couple of the generic interfaces.