### PR TITLE
Add backfill batch processors

### DIFF
--- a/src/main/scala/services/consumers/SqlServerChangeTracking.scala
+++ b/src/main/scala/services/consumers/SqlServerChangeTracking.scala
@@ -41,6 +41,7 @@ class SqlServerChangeTrackingBackfillBatch(batchName: String, batchSchema: Arcan
   
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
+  override val targetTableName: String = targetName
 
   override def reduceExpr: String =
     s"""SELECT * FROM $name AS ${MergeQueryCommons.SOURCE_ALIAS} WHERE ${MergeQueryCommons.SOURCE_ALIAS}.SYS_CHANGE_OPERATION != 'D'""".stripMargin

--- a/src/main/scala/services/consumers/StagedBatch.scala
+++ b/src/main/scala/services/consumers/StagedBatch.scala
@@ -49,7 +49,7 @@ trait StagedInitBatch extends StagedBatch:
 /**
  * Common trait for StagedBatch that performs a backfill operation on the table.
  */
-trait StagedBackfillBatch extends StagedBatch
+trait StagedBackfillBatch extends StagedBatch with MergeableBatch
 
 /**
  * StagedBatch that performs a backfill operation on the table in CREATE OR REPLACE mode.

--- a/src/main/scala/services/consumers/SynapseLink.scala
+++ b/src/main/scala/services/consumers/SynapseLink.scala
@@ -41,6 +41,7 @@ class SynapseLinkBackfillOverwriteBatch(batchName: String, batchSchema: ArcaneSc
 
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
+  override val targetTableName: String = targetName
 
   override def reduceExpr: String = s"""SELECT * FROM $name""".stripMargin
 

--- a/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/base/GenericStreamingGraphBuilder.scala
@@ -1,11 +1,10 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming.graph_builders.base
 
-import models.{DataRow, given_MetadataEnrichedRowStreamElement_DataRow}
 import services.app.base.StreamLifetimeService
-import services.streaming.base.{HookManager, MetadataEnrichedRowStreamElement, StreamDataProvider, StreamingGraphBuilder}
+import services.streaming.base.{HookManager, StreamDataProvider, StreamingGraphBuilder}
 import services.streaming.processors.GenericGroupingTransformer
-import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
+import services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 
 import zio.stream.ZStream

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
@@ -4,7 +4,7 @@ package services.streaming.processors.batch_processors.backfill
 import logging.ZIOLogAnnotations.*
 import services.base.DisposeServiceClient
 import services.consumers.StagedBackfillBatch
-import services.streaming.base.BatchProcessor
+import services.streaming.base.StreamingBatchProcessor
 
 import zio.stream.ZPipeline
 import zio.{ZIO, ZLayer}
@@ -13,7 +13,7 @@ import zio.{ZIO, ZLayer}
  * Processor that merges data into a target table.
  */
 class BackfillDisposeBatchProcessor(disposeServiceClient: DisposeServiceClient)
-  extends BatchProcessor:
+  extends StreamingBatchProcessor:
 
   override type BatchType = StagedBackfillBatch
 

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
@@ -24,7 +24,7 @@ class BackfillDisposeBatchProcessor(disposeServiceClient: DisposeServiceClient)
    */
   override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
     ZPipeline.mapZIO(batch =>
-      for _ <- zlog("Disposing batch with name: {batchName}", batch.name)
+      for _ <- zlog("Disposing batch (%s) with name: %s", batch.getClass.getName, batch.name)
           _ <- disposeServiceClient.disposeBatch(batch)
       yield batch
     )

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
@@ -24,7 +24,7 @@ class BackfillDisposeBatchProcessor(disposeServiceClient: DisposeServiceClient)
    */
   override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
     ZPipeline.mapZIO(batch =>
-      for _ <- zlog(s"Disposing batch with name ${batch.name}")
+      for _ <- zlog("Disposing batch with name: {batchName}", batch.name)
           _ <- disposeServiceClient.disposeBatch(batch)
       yield batch
     )

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillDisposeBatchProcessor.scala
@@ -1,0 +1,56 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.processors.batch_processors.backfill
+
+import logging.ZIOLogAnnotations.*
+import services.base.DisposeServiceClient
+import services.consumers.StagedBackfillBatch
+import services.streaming.base.BatchProcessor
+
+import zio.stream.ZPipeline
+import zio.{ZIO, ZLayer}
+
+/**
+ * Processor that merges data into a target table.
+ */
+class BackfillDisposeBatchProcessor(disposeServiceClient: DisposeServiceClient)
+  extends BatchProcessor:
+
+  override type BatchType = StagedBackfillBatch
+
+  /**
+   * Processes the incoming data.
+   *
+   * @return ZPipeline (stream source for the stream graph).
+   */
+  override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
+    ZPipeline.mapZIO(batch =>
+      for _ <- zlog(s"Disposing batch with name ${batch.name}")
+          _ <- disposeServiceClient.disposeBatch(batch)
+      yield batch
+    )
+
+object BackfillDisposeBatchProcessor:
+
+  /**
+   * Factory method to create MergeProcessor
+   *
+   * @param DisposeServiceClient The JDBC consumer.
+   * @return The initialized MergeProcessor instance
+   */
+  def apply(DisposeServiceClient: DisposeServiceClient): BackfillDisposeBatchProcessor =
+    new BackfillDisposeBatchProcessor(DisposeServiceClient)
+
+  /**
+   * The required environment for the BackfillMergeBatchProcessor.
+   */
+  type Environment = DisposeServiceClient
+
+  /**
+   * The ZLayer that creates the MergeProcessor.
+   */
+  val layer: ZLayer[Environment, Nothing, BackfillDisposeBatchProcessor] =
+    ZLayer {
+      for
+        disposeServiceClient <- ZIO.service[DisposeServiceClient]
+      yield BackfillDisposeBatchProcessor(disposeServiceClient)
+    }

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
@@ -1,0 +1,63 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.processors.batch_processors.backfill
+
+import logging.ZIOLogAnnotations.*
+import models.settings.*
+import services.base.MergeServiceClient
+import services.consumers.StagedBackfillBatch
+import services.merging.JdbcTableManager
+import services.streaming.base.*
+
+import zio.stream.ZPipeline
+import zio.{ZIO, ZLayer}
+
+/**
+ * Processor that merges data into a target table.
+ */
+class BackfillMergeBatchProcessor(mergeServiceClient: MergeServiceClient, tableManager: JdbcTableManager, targetTableSettings: TargetTableSettings)
+  extends BatchProcessor:
+
+  override type BatchType = StagedBackfillBatch
+
+  /**
+   * Processes the incoming data.
+   *
+   * @return ZPipeline (stream source for the stream graph).
+   */
+  override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
+    ZPipeline.mapZIO(batch =>
+      for _ <- zlog(s"Applying backfill batch to ${batch.targetTableName}")
+          _ <- tableManager.migrateSchema(batch.schema, batch.targetTableName)
+          _ <-  mergeServiceClient.applyBatch(batch)
+      yield  batch
+    )
+
+object BackfillMergeBatchProcessor:
+
+  /**
+   * Factory method to create MergeProcessor
+   *
+   * @param mergeServiceClient The JDBC consumer.
+   * @param tableManager The table manager.
+   * @param targetTableSettings The target table settings.
+   * @return The initialized MergeProcessor instance
+   */
+  def apply(mergeServiceClient: MergeServiceClient, tableManager: JdbcTableManager, targetTableSettings: TargetTableSettings): BackfillMergeBatchProcessor =
+    new BackfillMergeBatchProcessor(mergeServiceClient, tableManager, targetTableSettings)
+
+  /**
+   * The required environment for the BackfillMergeBatchProcessor.
+   */
+  type Environment = MergeServiceClient & JdbcTableManager & TargetTableSettings
+
+  /**
+   * The ZLayer that creates the MergeProcessor.
+   */
+  val layer: ZLayer[Environment, Nothing, BackfillMergeBatchProcessor] =
+    ZLayer {
+      for
+        jdbcConsumer <- ZIO.service[MergeServiceClient]
+        parallelismSettings <- ZIO.service[JdbcTableManager]
+        targetTableSettings <- ZIO.service[TargetTableSettings]
+      yield BackfillMergeBatchProcessor(jdbcConsumer, parallelismSettings, targetTableSettings)
+    }

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
@@ -26,7 +26,7 @@ class BackfillMergeBatchProcessor(mergeServiceClient: MergeServiceClient, tableM
    */
   override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
     ZPipeline.mapZIO(batch =>
-      for _ <- zlog(s"Applying backfill batch to ${batch.targetTableName}")
+      for _ <- zlog(s"Applying backfill batch: {batchName} to {targetTableName}", batch.name, batch.targetTableName)
           _ <- tableManager.migrateSchema(batch.schema, batch.targetTableName)
           _ <-  mergeServiceClient.applyBatch(batch)
       yield  batch

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
@@ -15,7 +15,7 @@ import zio.{ZIO, ZLayer}
  * Processor that merges data into a target table.
  */
 class BackfillMergeBatchProcessor(mergeServiceClient: MergeServiceClient, tableManager: JdbcTableManager, targetTableSettings: TargetTableSettings)
-  extends BatchProcessor:
+  extends StreamingBatchProcessor:
 
   override type BatchType = StagedBackfillBatch
 

--- a/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/backfill/BackfillMergeBatchProcessor.scala
@@ -26,7 +26,7 @@ class BackfillMergeBatchProcessor(mergeServiceClient: MergeServiceClient, tableM
    */
   override def process: ZPipeline[Any, Throwable, BatchType, BatchType] =
     ZPipeline.mapZIO(batch =>
-      for _ <- zlog(s"Applying backfill batch: {batchName} to {targetTableName}", batch.name, batch.targetTableName)
+      for _ <- zlog(s"Applying backfill batch (%s): %s to %s", batch.getClass.getName, batch.name, batch.targetTableName)
           _ <- tableManager.migrateSchema(batch.schema, batch.targetTableName)
           _ <-  mergeServiceClient.applyBatch(batch)
       yield  batch

--- a/src/main/scala/services/streaming/processors/batch_processors/streaming/DisposeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/streaming/DisposeBatchProcessor.scala
@@ -1,5 +1,5 @@
 package com.sneaksanddata.arcane.framework
-package services.streaming.processors.batch_processors
+package services.streaming.processors.batch_processors.streaming
 
 import logging.ZIOLogAnnotations.*
 import services.base.DisposeServiceClient

--- a/src/main/scala/services/streaming/processors/batch_processors/streaming/MergeBatchProcessor.scala
+++ b/src/main/scala/services/streaming/processors/batch_processors/streaming/MergeBatchProcessor.scala
@@ -1,5 +1,5 @@
 package com.sneaksanddata.arcane.framework
-package services.streaming.processors.batch_processors
+package services.streaming.processors.batch_processors.streaming
 
 import logging.ZIOLogAnnotations.*
 import models.settings.*

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -1,23 +1,23 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming
 
-import models.{ArcaneSchema, ArcaneType, DataCell, DataRow, MergeKeyField}
+import models.*
 import services.app.GenericStreamRunnerService
 import services.app.base.StreamRunnerService
 import services.base.{DisposeServiceClient, MergeServiceClient}
+import services.consumers.SqlServerChangeTrackingMergeBatch
 import services.filters.FieldsFilteringService
 import services.lakehouse.base.CatalogWriter
 import services.merging.JdbcTableManager
 import services.streaming.base.{HookManager, StreamDataProvider}
 import services.streaming.graph_builders.base.GenericStreamingGraphBuilder
 import services.streaming.processors.GenericGroupingTransformer
-import services.streaming.processors.batch_processors.{DisposeBatchProcessor, MergeBatchProcessor}
+import services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import services.streaming.processors.transformers.FieldFilteringTransformer.Environment
 import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 import services.streaming.processors.utils.TestIndexedStagedBatches
 import utils.*
 
-import com.sneaksanddata.arcane.framework.services.consumers.SqlServerChangeTrackingMergeBatch
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import org.easymock.EasyMock

--- a/src/test/scala/services/streaming/processors/MergeBatchProcessorTests.scala
+++ b/src/test/scala/services/streaming/processors/MergeBatchProcessorTests.scala
@@ -2,18 +2,14 @@ package com.sneaksanddata.arcane.framework
 package services.streaming.processors
 
 import models.ArcaneType.LongType
-import models.settings.{OptimizeSettings, OrphanFilesExpirationSettings, SnapshotExpirationSettings}
 import models.{ArcaneSchema, Field, MergeKeyField}
 import services.base.{BatchOptimizationResult, MergeServiceClient}
-import services.consumers.{MergeableBatch, StagedVersionedBatch, SynapseLinkMergeBatch}
+import services.consumers.SynapseLinkMergeBatch
 import services.merging.JdbcTableManager
-import services.merging.models.{JdbcOptimizationRequest, JdbcOrphanFilesExpirationRequest, JdbcSnapshotExpirationRequest}
-import services.streaming.base.{OptimizationRequestConvertable, OrphanFilesExpirationRequestConvertable, SnapshotExpirationRequestConvertable}
-import services.streaming.processors.batch_processors.MergeBatchProcessor
-import services.streaming.processors.transformers.IndexedStagedBatches
-
+import services.streaming.processors.batch_processors.streaming.MergeBatchProcessor
+import services.streaming.processors.utils.TestIndexedStagedBatches
 import com.sneaksanddata.arcane.framework.utils.{TablePropertiesSettings, TestTargetTableSettings, TestTargetTableSettingsWithMaintenance}
-import utils.TestIndexedStagedBatches
+
 import org.easymock.EasyMock
 import org.easymock.EasyMock.{replay, verify}
 import org.scalatest.flatspec.AsyncFlatSpec


### PR DESCRIPTION
Implemented:
- Added BackfillDisposeBatchProcessor class
- Added BackfillMergeBatchProcessor class
- Classes `MergeBatchProcessor` and `DisposeBatchProcessor` moved to the `streaming` package
- The `StagedBackfillBatch` trait now implements `MergeableBatch`