### PR TITLE
Rollback deleted interfaces

### DIFF
--- a/src/main/scala/services/streaming/base/BatchConsumer.scala
+++ b/src/main/scala/services/streaming/base/BatchConsumer.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import zio.stream.ZSink
+
+/**
+ * A trait that represents a grouped data batch consumer.
+ * @tparam ConsumableBatch The type of the consumable batch.
+ */
+trait BatchConsumer[ConsumableBatch]:
+
+  /**
+   * Returns the sink that consumes the batch.
+   *
+   * @return ZSink (stream sink for the stream graph).
+   */
+  def consume: ZSink[Any, Throwable, ConsumableBatch, Any, Unit]

--- a/src/main/scala/services/streaming/base/StagedBatchProcessor.scala
+++ b/src/main/scala/services/streaming/base/StagedBatchProcessor.scala
@@ -53,7 +53,7 @@ trait OrphanFilesExpirationRequestConvertable:
 /**
  * A trait that represents a batch processor.
  */
-trait StagedBatchProcessor extends BatchProcessor:
+trait StagedBatchProcessor extends StreamingBatchProcessor:
 
   /**
    * @inheritdoc

--- a/src/main/scala/services/streaming/base/StreamingBatchProcessor.scala
+++ b/src/main/scala/services/streaming/base/StreamingBatchProcessor.scala
@@ -4,15 +4,18 @@ package services.streaming.base
 import zio.stream.ZPipeline
 
 /**
- * A trait that represents a batch processor.
- * @tparam IncomingType The type of the incoming data.
+ * Represents a streaming stage that processes batches.
  */
-trait BatchProcessor[IncomingType, OutgoingType] {
+trait StreamingBatchProcessor:
+
+  /**
+   * The type of the batch.
+   */
+  type BatchType
 
   /**
    * Processes the incoming data.
    *
    * @return ZPipeline (stream source for the stream graph).
    */
-  def process: ZPipeline[Any, Throwable, IncomingType, OutgoingType]
-}
+  def process: ZPipeline[Any, Throwable, BatchType, BatchType]


### PR DESCRIPTION
This is partial rollback of #68

The Microsoft Synapse Link Arcane plugin references two deleted interfaces and we need to get them back for a short period of time.

Restored interfaces: `BatchConsumer`, `BatchProcessor`