### PR TITLE
Fix incorrect datetime iterator

### DIFF
--- a/src/main/scala/services/cdm/AzureBlobStorageReaderExtensions.scala
+++ b/src/main/scala/services/cdm/AzureBlobStorageReaderExtensions.scala
@@ -109,7 +109,7 @@ object AzureBlobStorageReaderExtensions:
    */
   extension (reader: BlobStorageReader[AdlsStoragePath]) def getRootPrefixes(storagePath: AdlsStoragePath, startFrom: OffsetDateTime, endDate: OffsetDateTime): BlobStream =
     for _ <- zlogStream("Getting root prefixes stating from " + startFrom)
-        prefix <- ZStream.fromIterable(getListPrefixes(startFrom, endDate))
+        prefix <- ZStream.fromIterable(getPrefixesList(startFrom, endDate))
         blob <- reader.streamPrefixes(storagePath + prefix)
         zippedWithDate = (interpretAsDate(blob), blob)
         eligibleToProcess <- zippedWithDate match
@@ -128,9 +128,9 @@ object AzureBlobStorageReaderExtensions:
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH.mm.ssX")
     Try(OffsetDateTime.parse(name, formatter)).toOption
 
-  private def getListPrefixes(startDate: OffsetDateTime, endDate: OffsetDateTime): Seq[String] =
+  private def getPrefixesList(startDate: OffsetDateTime, endDate: OffsetDateTime): Seq[String] =
     val defaultFromYears: Int = 1
-    val currentMoment = endDate
+    val currentMoment = endDate.plusHours(1)
     val startMoment = startDate
     Iterator.iterate(startMoment)(_.plusHours(1))
       .takeWhile(_.toEpochSecond < currentMoment.toEpochSecond)

--- a/src/test/scala/services/cdm/TableFilesStreamSourceTests.scala
+++ b/src/test/scala/services/cdm/TableFilesStreamSourceTests.scala
@@ -52,10 +52,10 @@ class TableFilesStreamSourceTests extends AsyncFlatSpec with Matchers with EasyM
     // Arrange
     val reader = mock[BlobStorageReader[AdlsStoragePath]]
 
-    val rootBlob = StoredBlob(name = "2021-10-01T00.00.00Z", createdOn = None)
-    val tableBlob = StoredBlob(name = "2021-10-01T00.00.00Z/table/", createdOn = None)
-    val fileBlob = StoredBlob(name = "2021-10-01T00.00.00Z/table/1.csv", createdOn = None)
-    val modelBlobName = "2021-10-01T00.00.00Z/model.json"
+    val rootBlob = StoredBlob(name = "2021-09-01T00.00.00Z", createdOn = None)
+    val tableBlob = StoredBlob(name = "2021-09-01T00.00.00Z/table/", createdOn = None)
+    val fileBlob = StoredBlob(name = "2021-09-01T00.00.00Z/table/1.csv", createdOn = None)
+    val modelBlobName = "2021-09-01T00.00.00Z/model.json"
 
     val modelBlobContent =
       """
@@ -84,11 +84,17 @@ class TableFilesStreamSourceTests extends AsyncFlatSpec with Matchers with EasyM
 
       // The changelog file is read 4 times, once for the initial read, and twice for the change capture stream
       reader.streamBlobContent(AdlsStoragePath("storageAccount", "container", "Changelog/changelog.info"))
-        .andReturn(ZIO.attempt(new BufferedReader(new StringReader("2021-09-01T00.00.00Z"))))
+        .andReturn(ZIO.attempt(new BufferedReader(new StringReader("2021-09-01T00.05.00Z"))))
         .atLeastOnce()
 
       // Iterate over timestamps, starting from the current time minus at least one hour.
       reader.streamPrefixes(AdlsStoragePath("storageAccount","container", "2021-08-31T23"))
+        // We mock the stream to return the same blob twice since the stream drops the last element
+        .andReturn(ZStream.fromIterable(Seq(rootBlob, rootBlob)))
+        .anyTimes()
+
+      // Iterate over timestamps, starting from the current time minus at least one hour.
+      reader.streamPrefixes(AdlsStoragePath("storageAccount","container", "2021-09-01T00"))
         // We mock the stream to return the same blob twice since the stream drops the last element
         .andReturn(ZStream.fromIterable(Seq(rootBlob, rootBlob)))
         .anyTimes()
@@ -107,7 +113,7 @@ class TableFilesStreamSourceTests extends AsyncFlatSpec with Matchers with EasyM
       // Since the stream is called twice, we must return the same content twice (once for each read)
       reader.streamBlobContent(AdlsStoragePath("storageAccount","container", modelBlobName))
         .andReturn(ZIO.succeed(new BufferedReader(new StringReader(modelBlobContent))))
-        .times(1, 3)
+        .times(2)
 
       // We must return true when checking if the blob exists since the stream checks if the model.json exists and
       // filters out the prefixes that do not have it
@@ -120,7 +126,7 @@ class TableFilesStreamSourceTests extends AsyncFlatSpec with Matchers with EasyM
     val tableSettings = CdmTableSettings("table", "abfss://container@storageAccount.dfs.core.windows.net/")
 
     // Act
-    val stream = new TableFilesStreamSource(settings, reader, path, tableSettings).changeCaptureStream.take(3).runCollect
+    val stream = new TableFilesStreamSource(settings, reader, path, tableSettings).changeCaptureStream.take(2).runCollect
 
     // Assert
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(stream)).map { _ =>

--- a/src/test/scala/services/merging/JdbcMergeServiceClientTests.scala
+++ b/src/test/scala/services/merging/JdbcMergeServiceClientTests.scala
@@ -174,9 +174,9 @@ class JdbcMergeServiceClientTests extends AsyncFlatSpec with Matchers with EasyM
 
 
     val mergeServiceClient = getSystemUnderTest(Some(schemaProviderFactory))
-    for newSchema <- mergeServiceClient.getSchema("table_a")
-        newSchema <- mergeServiceClient.getSchema("table_a")
-        result <- mergeServiceClient.migrateSchema(updatedSchema, "table_a")
+
+    // The schema provider should be called twice, once for the original schema and once for the updated schema
+    for result <- mergeServiceClient.migrateSchema(updatedSchema, "table_a") // First and second calls here
         result <- mergeServiceClient.migrateSchema(updatedSchema, "table_a")
         result <- mergeServiceClient.migrateSchema(updatedSchema, "table_a")
         result <- mergeServiceClient.migrateSchema(updatedSchema, "table_a")


### PR DESCRIPTION
Fixes #87

Adding plus one hour to the `endDate` parameter and adding the unit test that is able to reproduce the problem