### PR TITLE
Reuse the staging table for staging batches

### DIFF
--- a/src/main/scala/models/settings/StagingDataSettings.scala
+++ b/src/main/scala/models/settings/StagingDataSettings.scala
@@ -5,14 +5,28 @@ import java.time.{ZoneOffset, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
+/**
+ * Represents the settings for staging data.
+ */
 trait StagingDataSettings:
+
+  /**
+   * The prefix for the staging table.
+   */
   val stagingTablePrefix: String
-  
+
+  /**
+   * The name of the staging catalog.
+   */
   val stagingCatalogName: String
-  
+
+  /**
+   * The name of the staging schema.
+   */
   val stagingSchemaName: String
-  
-  def newStagingTableName: String =
-    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
-    val id = UUID.randomUUID().toString
-    s"${stagingTablePrefix}__${ZonedDateTime.now(ZoneOffset.UTC).format(formatter)}_$id".replace('-', '_')
+
+
+  /**
+   * The name of the staging table. For now, it's just a prefix.
+   */
+  def getStagingTableName: String = stagingTablePrefix

--- a/src/main/scala/services/app/GenericStreamRunnerService.scala
+++ b/src/main/scala/services/app/GenericStreamRunnerService.scala
@@ -30,11 +30,8 @@ class GenericStreamRunnerService(builder: StreamingGraphBuilder,
     lifetimeService.start()
     for
       _ <- zlog("Starting the stream runner")
-      _ <- tableManager.cleanupStagingTables(stagingDataSettings.stagingCatalogName,
-        stagingDataSettings.stagingSchemaName,
-        stagingDataSettings.stagingTablePrefix)
-      
       _ <- tableManager.createTargetTable
+      _ <- tableManager.createStagingTable
       _ <- tableManager.createBackFillTable
       _ <- builder.produce.via(streamLifetimeGuard).run(logResults)
       _ <- zlog("Stream completed")

--- a/src/main/scala/services/base/TableManager.scala
+++ b/src/main/scala/services/base/TableManager.scala
@@ -100,17 +100,6 @@ trait TableManager:
   def migrateSchema(newSchema: ArcaneSchema, tableName: String): Task[Unit]
 
   /**
-   * Cleans up the staging tables in the specific catalog by table name prefix.
-   * This method is used to ensure that the staging tables are cleaned up after the streaming job restart.
-   *
-   * @param stagingCatalogName The catalog of the staging table.
-   * @param stagingSchemaName The catalog of the staging table.
-   * @param tableNamePrefix The prefix of the staging table name.
-   * @return The list of tables.
-   */
-  def cleanupStagingTables(stagingCatalogName: String, stagingSchemaName: String, tableNamePrefix: String): Task[Unit]
-
-  /**
    * Creates the target table.
    *
    * @return The result of the target table creation operation.
@@ -123,3 +112,10 @@ trait TableManager:
    * @return The result of the archive table creation operation.
    */
   def createBackFillTable: Task[Unit]
+
+  /**
+   * Creates the archive table.
+   *
+   * @return The result of the archive table creation operation.
+   */
+  def createStagingTable: Task[Unit]

--- a/src/main/scala/services/cdm/SynapseHookManager.scala
+++ b/src/main/scala/services/cdm/SynapseHookManager.scala
@@ -19,13 +19,14 @@ class SynapseHookManager extends EmptyHookManager:
    * Converts the batch to a format that can be consumed by the next processor.
    * */
   def onBatchStaged(table: Table,
+                    batchId: String,
                     namespace: String,
                     warehouse: String,
                     batchSchema: ArcaneSchema,
                     targetName: String,
                     tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch & MergeableBatch =
     val batchName = table.name().split('.').last
-    SynapseLinkMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings)
+    SynapseLinkMergeBatch(batchName, batchId, batchSchema, targetName, tablePropertiesSettings)
 
 
 object SynapseHookManager:

--- a/src/main/scala/services/consumers/SqlServerChangeTracking.scala
+++ b/src/main/scala/services/consumers/SqlServerChangeTracking.scala
@@ -56,7 +56,7 @@ object  SqlServerChangeTrackingBackfillBatch:
   def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, archiveName: String, tablePropertiesSettings: TablePropertiesSettings): StagedBackfillOverwriteBatch =
     new SqlServerChangeTrackingBackfillBatch(batchName, batchSchema, targetName, archiveName, tablePropertiesSettings)
 
-class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String)
+class SqlServerChangeTrackingMergeBatch(batchName: String, val batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String)
   extends StagedVersionedBatch
   with MergeableBatch:
   
@@ -78,5 +78,5 @@ class SqlServerChangeTrackingMergeBatch(batchName: String, batchSchema: ArcaneSc
   def archiveExpr(archiveTableName: String): String = s"INSERT INTO $archiveTableName $reduceExpr"
 
 object SqlServerChangeTrackingMergeBatch:
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SqlServerChangeTrackingMergeBatch =
-    new SqlServerChangeTrackingMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)
+  def apply(batchName: String, batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SqlServerChangeTrackingMergeBatch =
+    new SqlServerChangeTrackingMergeBatch(batchName, batchId, batchSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)

--- a/src/main/scala/services/consumers/StagedBatch.scala
+++ b/src/main/scala/services/consumers/StagedBatch.scala
@@ -11,6 +11,11 @@ trait MergeableBatch:
    */
   val targetTableName: String
 
+  /**
+   * The unique identifier for the batch
+   */
+  val batchId: String
+
 trait StagedBatch:
 
   type Query <: StreamingBatchQuery

--- a/src/main/scala/services/consumers/SynapseLink.scala
+++ b/src/main/scala/services/consumers/SynapseLink.scala
@@ -50,7 +50,7 @@ object  SynapseLinkBackfillOverwriteBatch:
   def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkBackfillOverwriteBatch =
     new SynapseLinkBackfillOverwriteBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings)
 
-class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch with MergeableBatch:
+class SynapseLinkMergeBatch(batchName: String, val batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String) extends StagedVersionedBatch with MergeableBatch:
   override val name: String = batchName
   override val schema: ArcaneSchema = batchSchema
   override val targetTableName: String = targetName
@@ -65,10 +65,10 @@ class SynapseLinkMergeBatch(batchName: String, batchSchema: ArcaneSchema, target
     SynapseLinkMergeQuery(targetName = targetName, sourceQuery = reduceExpr, partitionFields = tablePropertiesSettings.partitionFields, mergeKey = mergeKey, columns = schema.map(f => f.name))
 
 object SynapseLinkMergeBatch:
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkMergeBatch =
-    new SynapseLinkMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)
+  def apply(batchName: String, batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkMergeBatch =
+    new SynapseLinkMergeBatch(batchName, batchId, batchSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)
 
-class SynapseLinkBackfillMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName: String,  tablePropertiesSettings: TablePropertiesSettings, mergeKey: String)
+class SynapseLinkBackfillMergeBatch(batchName: String, val batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings, mergeKey: String)
   extends StagedBackfillMergeBatch with MergeableBatch:
 
   override val name: String = batchName
@@ -80,6 +80,6 @@ class SynapseLinkBackfillMergeBatch(batchName: String, batchSchema: ArcaneSchema
   override val batchQuery: MergeQuery = SynapseLinkMergeQuery(targetName = targetName, sourceQuery = reduceExpr, partitionFields = tablePropertiesSettings.partitionFields, mergeKey = mergeKey, columns = schema.map(f => f.name))
 
 object SynapseLinkBackfillMergeBatch:
-  def apply(batchName: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkBackfillMergeBatch =
-    new SynapseLinkBackfillMergeBatch(batchName: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)
+  def apply(batchName: String, batchId: String, batchSchema: ArcaneSchema, targetName: String, tablePropertiesSettings: TablePropertiesSettings): SynapseLinkBackfillMergeBatch =
+    new SynapseLinkBackfillMergeBatch(batchName: String, batchId: String, batchSchema: ArcaneSchema, targetName, tablePropertiesSettings, batchSchema.mergeKey.name)
 

--- a/src/main/scala/services/merging/JdbcMergeServiceClient.scala
+++ b/src/main/scala/services/merging/JdbcMergeServiceClient.scala
@@ -19,10 +19,10 @@ import services.merging.models.given_SqlExpressionConvertable_JdbcOrphanFilesExp
 import services.lakehouse.SchemaConversions
 import services.merging.JdbcMergeServiceClient.{generateAlterTableSQL, readStrings}
 import utils.SqlUtils.readArcaneSchema
-import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
 
+import com.sneaksanddata.arcane.framework.models.given_CanAdd_ArcaneSchema
 import com.sneaksanddata.arcane.framework.models.app.StreamContext
-import com.sneaksanddata.arcane.framework.models.settings.{BackfillSettings, TablePropertiesSettings, TargetTableSettings}
+import com.sneaksanddata.arcane.framework.models.settings.{BackfillSettings, StagingDataSettings, TablePropertiesSettings, TargetTableSettings}
 import com.sneaksanddata.arcane.framework.services.filters.FieldsFilteringService
 import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClient.generateCreateTableSQL
 import org.apache.iceberg.Schema
@@ -90,6 +90,7 @@ type SchemaProviderFactory = (String, Connection) => SchemaProvider[ArcaneSchema
 class JdbcMergeServiceClient(options: JdbcMergeServiceClientOptions,
                              targetTableSettings: TargetTableSettings,
                              backfillTableSettings: BackfillSettings,
+                             stagingDataSettings: StagingDataSettings,
                              streamContext: StreamContext,
                              schemaProvider: SchemaProvider[ArcaneSchema],
                              fieldsFilteringService: FieldsFilteringService,
@@ -155,21 +156,6 @@ class JdbcMergeServiceClient(options: JdbcMergeServiceClientOptions,
   /**
    * @inheritdoc
    */
-  def cleanupStagingTables(stagingCatalogName: String, stagingSchemaName: String, tableNamePrefix: String): Task[Unit] =
-    val sql = s"SHOW TABLES FROM $stagingCatalogName.$stagingSchemaName LIKE '$tableNamePrefix\\_\\_%' escape '\\'"
-    ZIO.scoped {
-      for statement <- ZIO.fromAutoCloseable(ZIO.attemptBlocking(sqlConnection.prepareStatement(sql)))
-          resultSet <- ZIO.attemptBlocking(statement.executeQuery())
-          tableNames <- ZIO.attemptBlocking(readStrings(resultSet))
-          _ <- ZIO.foreachDiscard(tableNames)(tableName => {
-            zlog("Found lost staging table: " + tableName) *> dropTable(tableName)
-          })
-      yield ()
-    }
-
-  /**
-   * @inheritdoc
-   */
   def createTargetTable: Task[Unit] =
     for
       _ <- zlog("Creating target table", Seq(getAnnotation("targetTableName", targetTableSettings.targetTableFullName)))
@@ -190,6 +176,15 @@ class JdbcMergeServiceClient(options: JdbcMergeServiceClientOptions,
     else
       ZIO.unit
 
+  /**
+   * @inheritdoc
+   */
+  def createStagingTable: Task[Unit] =
+    for
+      _ <- zlog("Creating staging table", Seq(getAnnotation("stagingTableName", stagingDataSettings.getStagingTableName)))
+      schema: ArcaneSchema <- schemaProvider.getSchema
+      created <- createTable(stagingDataSettings.getStagingTableName, fieldsFilteringService.filter(schema), tablePropertiesSettings)
+    yield ()
 
   private def createTable(name: String, schema: Schema, properties: TablePropertiesSettings): Task[Unit] =
     ZIO.attemptBlocking(sqlConnection.prepareStatement(generateCreateTableSQL(name, schema, properties)).execute())
@@ -276,6 +271,7 @@ object JdbcMergeServiceClient:
     & StreamContext
     & BackfillSettings
     & SchemaCache
+    & StagingDataSettings
 
   /**
    * Factory method to create JdbcConsumer.
@@ -285,13 +281,14 @@ object JdbcMergeServiceClient:
   def apply(options: JdbcMergeServiceClientOptions,
             targetTableSettings: TargetTableSettings,
             backfillTableSettings: BackfillSettings,
+            stagingDataSettings: StagingDataSettings,
             streamContext: StreamContext,
             schemaProvider: SchemaProvider[ArcaneSchema],
             fieldsFilteringService: FieldsFilteringService,
             tablePropertiesSettings: TablePropertiesSettings,
             schemaProviderManager: SchemaCache,
             maybeSchemaProviderFactory: Option[SchemaProviderFactory]): JdbcMergeServiceClient =
-    new JdbcMergeServiceClient(options, targetTableSettings, backfillTableSettings, streamContext, schemaProvider, fieldsFilteringService, tablePropertiesSettings, schemaProviderManager, maybeSchemaProviderFactory)
+    new JdbcMergeServiceClient(options, targetTableSettings, backfillTableSettings, stagingDataSettings, streamContext, schemaProvider, fieldsFilteringService, tablePropertiesSettings, schemaProviderManager, maybeSchemaProviderFactory)
 
   /**
    * The ZLayer that creates the JdbcConsumer.
@@ -303,11 +300,12 @@ object JdbcMergeServiceClient:
           connectionOptions <- ZIO.service[JdbcMergeServiceClientOptions]
           targetTableSettings <- ZIO.service[TargetTableSettings]
           backfillTableSettings <- ZIO.service[BackfillSettings]
+          stagingDataSettings <- ZIO.service[StagingDataSettings]
           schemaProvider <- ZIO.service[SchemaProvider[ArcaneSchema]]
           fieldsFilteringService <- ZIO.service[FieldsFilteringService]
           tablePropertiesSettings <- ZIO.service[TablePropertiesSettings]
           streamContext <- ZIO.service[StreamContext]
           schemaProviderManager <- ZIO.service[SchemaCache]
-        yield JdbcMergeServiceClient(connectionOptions, targetTableSettings, backfillTableSettings, streamContext, schemaProvider, fieldsFilteringService, tablePropertiesSettings, schemaProviderManager, None)
+        yield JdbcMergeServiceClient(connectionOptions, targetTableSettings, backfillTableSettings, stagingDataSettings, streamContext, schemaProvider, fieldsFilteringService, tablePropertiesSettings, schemaProviderManager, None)
       }
     }

--- a/src/main/scala/services/mssql/MsSqlHookManager.scala
+++ b/src/main/scala/services/mssql/MsSqlHookManager.scala
@@ -19,13 +19,14 @@ class MsSqlHookManager extends EmptyHookManager:
    * Converts the batch to a format that can be consumed by the next processor.
    * */
   def onBatchStaged(table: Table,
+                    batchId: String,
                     namespace: String,
                     warehouse: String,
                     batchSchema: ArcaneSchema,
                     targetName: String,
                     tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch & MergeableBatch =
     val batchName = table.name().split('.').last
-    SqlServerChangeTrackingMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings)
+    SqlServerChangeTrackingMergeBatch(batchName, batchId, batchSchema, targetName, tablePropertiesSettings)
 
 
 object MsSqlHookManager:

--- a/src/main/scala/services/streaming/base/HookManager.scala
+++ b/src/main/scala/services/streaming/base/HookManager.scala
@@ -23,7 +23,8 @@ trait HookManager:
   /**
    * Converts the batch to a format that can be consumed by the next processor.
    * */
-  def onBatchStaged(table: Table, 
+  def onBatchStaged(table: Table,
+                    batchId: String,
                     namespace: String,
                     warehouse: String,
                     batchSchema: ArcaneSchema,

--- a/src/main/scala/services/streaming/base/RowGroupTransformer.scala
+++ b/src/main/scala/services/streaming/base/RowGroupTransformer.scala
@@ -31,7 +31,7 @@ trait RowGroupTransformer:
   type OutgoingElement <: IndexedStagedBatches
   
   type OnStagingTablesComplete = (Iterable[StagedVersionedBatch & MergeableBatch], Long, Chunk[Any]) => OutgoingElement
-  type OnBatchStaged = (Table, String, String, ArcaneSchema, String, TablePropertiesSettings) => StagedVersionedBatch & MergeableBatch
+  type OnBatchStaged = (Table, String, String, String, ArcaneSchema, String, TablePropertiesSettings) => StagedVersionedBatch & MergeableBatch
   
   type IncomingElement = DataRow|Any
   

--- a/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
+++ b/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
@@ -4,19 +4,22 @@ package services.streaming.processors.transformers
 import logging.ZIOLogAnnotations.zlog
 import models.DataCell.schema
 import models.settings.{StagingDataSettings, TablePropertiesSettings, TargetTableSettings}
-import models.{ArcaneSchema, DataRow}
+import models.{ArcaneSchema, DataCell, DataRow}
 import services.consumers.{MergeableBatch, StagedVersionedBatch, SynapseLinkMergeBatch}
 import services.lakehouse.base.{CatalogWriter, IcebergCatalogSettings}
 import services.lakehouse.given_Conversion_ArcaneSchema_Schema
 import services.streaming.base.{MetadataEnrichedRowStreamElement, RowGroupTransformer, StagedBatchProcessor}
-import services.streaming.processors.transformers.StagingProcessor.toStagedBatch
 
+import com.sneaksanddata.arcane.framework.models.ArcaneType.{LongType, StringType}
+import com.sneaksanddata.arcane.framework.services.merging.JdbcTableManager
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor.addBatchId
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.stream.ZPipeline
 import zio.{Chunk, Schedule, Task, ZIO, ZLayer}
 
 import java.time.Duration
+import java.util.UUID
 
 trait IndexedStagedBatches(val groupedBySchema: Iterable[StagedVersionedBatch & MergeableBatch], val batchIndex: Long)
 
@@ -25,7 +28,8 @@ class StagingProcessor(stagingDataSettings: StagingDataSettings,
                        tablePropertiesSettings: TablePropertiesSettings,
                        targetTableSettings: TargetTableSettings,
                        icebergCatalogSettings: IcebergCatalogSettings,
-                       catalogWriter: CatalogWriter[RESTCatalog, Table, Schema])
+                       catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
+                       tableManager: JdbcTableManager)
 
   extends RowGroupTransformer:
 
@@ -41,17 +45,23 @@ class StagingProcessor(stagingDataSettings: StagingDataSettings,
       .mapZIO(elements =>
         val groupedBySchema = elements.withFilter(e => e.isInstanceOf[DataRow]).map(e => e.asInstanceOf[DataRow]).groupBy(row => row.schema)
         val others = elements.filterNot(e => e.isInstanceOf[DataRow])
-        val applyTasks = ZIO.foreach(groupedBySchema.keys)(schema => writeDataRows(groupedBySchema(schema), schema, onBatchStaged))
+        val applyTasks = ZIO.foreach(groupedBySchema.keys) { schema =>
+          val batchId = UUID.randomUUID().toString
+          writeDataRows(groupedBySchema(schema).map(r => r.addBatchId(batchId)), batchId, schema, onBatchStaged)
+        }
         applyTasks.map(batches => (batches, others))
       )
       .zipWithIndex
       .map { case ((batches, others), index) => onStagingTablesComplete(batches, index, others) }
 
-  private def writeDataRows(rows: Chunk[DataRow], arcaneSchema: ArcaneSchema, onBatchStaged: OnBatchStaged): Task[StagedVersionedBatch & MergeableBatch] =
-    val tableWriterEffect = zlog("Attempting to write data to staging table") *> catalogWriter.write(rows, stagingDataSettings.newStagingTableName, arcaneSchema)
+  private def writeDataRows(rows: Chunk[DataRow], batchId: String, arcaneSchema: ArcaneSchema, onBatchStaged: OnBatchStaged): Task[StagedVersionedBatch & MergeableBatch] =
+    val tableWriterEffect = zlog("Attempting to write data to staging table") *> catalogWriter.write(rows, stagingDataSettings.getStagingTableName, arcaneSchema)
+
     for
-      table <- tableWriterEffect.tapErrorCause(cause => zlog(s"Error writing data to staging table: $cause")).retry(retryPolicy)
+      _ <- tableManager.migrateSchema(arcaneSchema, stagingDataSettings.getStagingTableName)
+      table <- tableWriterEffect.tapErrorCause(cause => zlog("Error writing data to staging table: {cause}", cause)).retry(retryPolicy)
       batch = onBatchStaged(table,
+        batchId,
         icebergCatalogSettings.namespace,
         icebergCatalogSettings.warehouse,
         arcaneSchema,
@@ -59,31 +69,32 @@ class StagingProcessor(stagingDataSettings: StagingDataSettings,
         tablePropertiesSettings)
     yield batch
 
-
 object StagingProcessor:
 
-  extension (table: Table) def toStagedBatch(namespace: String,
-                                             warehouse: String,
-                                             batchSchema: ArcaneSchema,
-                                             targetName: String,
-                                             tablePropertiesSettings: TablePropertiesSettings): StagedVersionedBatch & MergeableBatch =
-    val batchName = table.name().split('.').last
-    SynapseLinkMergeBatch(batchName, batchSchema, targetName, tablePropertiesSettings)
-
-  def apply(stagingDataSettings: StagingDataSettings,
-            tablePropertiesSettings: TablePropertiesSettings,
-            targetTableSettings: TargetTableSettings,
-            icebergCatalogSettings: IcebergCatalogSettings,
-            catalogWriter: CatalogWriter[RESTCatalog, Table, Schema]): StagingProcessor =
-    new StagingProcessor(stagingDataSettings, tablePropertiesSettings, targetTableSettings, icebergCatalogSettings, catalogWriter)
-
+  /**
+   * Adds a batch id to the row.
+   *
+   * @param batchId The batch id to add.
+   * @param row The row to add the batch id to.
+   * @return The row with the batch id added.
+   */
+  extension (row: DataRow)
+    def addBatchId(batchId: String): DataRow = row :+ DataCell("ARCANE_BATCH_ID", StringType, batchId)
 
   type Environment = StagingDataSettings
     & TablePropertiesSettings
     & TargetTableSettings
     & IcebergCatalogSettings
     & CatalogWriter[RESTCatalog, Table, Schema]
+    & JdbcTableManager
 
+  def apply(stagingDataSettings: StagingDataSettings,
+            tablePropertiesSettings: TablePropertiesSettings,
+            targetTableSettings: TargetTableSettings,
+            icebergCatalogSettings: IcebergCatalogSettings,
+            catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
+            tableManager: JdbcTableManager): StagingProcessor =
+    new StagingProcessor(stagingDataSettings, tablePropertiesSettings, targetTableSettings, icebergCatalogSettings, catalogWriter, tableManager)
 
   val layer: ZLayer[Environment, Nothing, StagingProcessor] =
     ZLayer {
@@ -93,5 +104,6 @@ object StagingProcessor:
         targetTableSettings <- ZIO.service[TargetTableSettings]
         icebergCatalogSettings <- ZIO.service[IcebergCatalogSettings]
         catalogWriter <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
-      yield StagingProcessor(stagingDataSettings, tablePropertiesSettings, targetTableSettings, icebergCatalogSettings, catalogWriter)
+        tableManager <- ZIO.service[JdbcTableManager]
+      yield StagingProcessor(stagingDataSettings, tablePropertiesSettings, targetTableSettings, icebergCatalogSettings, catalogWriter, tableManager)
     }

--- a/src/test/scala/services/consumers/SqlServerChangeTrackingTests.scala
+++ b/src/test/scala/services/consumers/SqlServerChangeTrackingTests.scala
@@ -71,7 +71,7 @@ class SqlServerChangeTrackingTests extends AnyFlatSpec with Matchers:
   }
 
   "SqlServerChangeTrackingMergeBatch" should "generate a valid versioned batch" in {
-    val batch = SqlServerChangeTrackingMergeBatch("test.staged_a", Seq(
+    val batch = SqlServerChangeTrackingMergeBatch("test.staged_a", "batchId", Seq(
       MergeKeyField,
         Field(
           name = "colA",

--- a/src/test/scala/services/consumers/SynapseLinkTests.scala
+++ b/src/test/scala/services/consumers/SynapseLinkTests.scala
@@ -89,7 +89,7 @@ class SynapseLinkTests extends AnyFlatSpec with Matchers:
   }
   
   "SynapseLinkBackfillMergeBatch" should "generate a valid backfill merge batch" in {
-    val batch = SynapseLinkBackfillMergeBatch("test.staged_a", Seq(
+    val batch = SynapseLinkBackfillMergeBatch("test.staged_a", "batchId", Seq(
       MergeKeyField,
       Field(
         name = "colA",
@@ -119,7 +119,7 @@ class SynapseLinkTests extends AnyFlatSpec with Matchers:
   }
 
   "SynapseLinkMergeBatch" should "generate a valid versioned batch" in {
-    val batch = SynapseLinkMergeBatch("test.staged_a", Seq(
+    val batch = SynapseLinkMergeBatch("test.staged_a", "table_id", Seq(
       MergeKeyField,
       Field(
         name = "colA",

--- a/src/test/scala/services/merging/JdbcMergeServiceClientTests.scala
+++ b/src/test/scala/services/merging/JdbcMergeServiceClientTests.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.merging
 
 import services.consumers.SynapseLinkMergeBatch
-import utils.{TestBackfillTableSettings, TestTablePropertiesSettings, TestTargetTableSettings}
+import utils.{TestBackfillTableSettings, TestStagingDataSettings, TestTablePropertiesSettings, TestTargetTableSettings}
 
 import com.sneaksanddata.arcane.framework.models.{ArcaneSchema, Field, MergeKeyField}
 import com.sneaksanddata.arcane.framework.models.ArcaneType.{BooleanType, LongType, StringType}
@@ -78,6 +78,7 @@ class JdbcMergeServiceClientTests extends AsyncFlatSpec with Matchers with EasyM
   private def getSystemUnderTest(schemaProviderFactory: Option[SchemaProviderFactory]) = new JdbcMergeServiceClient(options,
       TestTargetTableSettings,
       TestBackfillTableSettings,
+      TestStagingDataSettings,
       streamContext,
       schemaProviderMock,
       fieldsFilteringServiceMock,
@@ -86,7 +87,7 @@ class JdbcMergeServiceClientTests extends AsyncFlatSpec with Matchers with EasyM
       schemaProviderFactory)
 
   it should "should be able to apply a batch to target table" in withTargetTable("table_a") { connection =>
-    val batch = SynapseLinkMergeBatch("test.staged_table_a", schema, "test.table_a", TestTablePropertiesSettings)
+    val batch = SynapseLinkMergeBatch("test.staged_table_a", "table_id", schema, "test.table_a", TestTablePropertiesSettings)
     val mergeServiceClient = getSystemUnderTest(None)
 
     for _ <- mergeServiceClient.applyBatch(batch)
@@ -100,7 +101,7 @@ class JdbcMergeServiceClientTests extends AsyncFlatSpec with Matchers with EasyM
 
   it should "should be able to dispose a batch" in withTargetTable("table_a") { connection =>
     val mergeServiceClient = getSystemUnderTest(None)
-    val batch = SynapseLinkMergeBatch("test.staged_table_a", schema, "test.table_a", TestTablePropertiesSettings)
+    val batch = SynapseLinkMergeBatch("test.staged_table_a", "batch_id", schema, "test.table_a", TestTablePropertiesSettings)
 
     for _ <- mergeServiceClient.disposeBatch(batch)
         rs = connection.getMetaData.getTables(null, null, "staged_table_a", null)

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -88,6 +88,9 @@ class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with E
       jdbcTableManager.createBackFillTable
         .andReturn(ZIO.unit)
         .anyTimes()
+      jdbcTableManager.migrateSchema(EasyMock.anyObject(), EasyMock.anyString())
+        .andReturn(ZIO.unit)
+        .anyTimes()
     }
     replay(catalogWriter, streamDataProvider, tableMock, hookManager, jdbcTableManager)
 

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -75,11 +75,11 @@ class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with E
         .andReturn(new TestIndexedStagedBatches(List.empty, 0))
         .times(streamRepeatCount)
       hookManager
-        .onBatchStaged(EasyMock.anyObject(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject(), EasyMock.anyString(), EasyMock.anyObject())
-        .andReturn(SqlServerChangeTrackingMergeBatch("test", ArcaneSchema(Seq(MergeKeyField)), "test", TablePropertiesSettings))
+        .onBatchStaged(EasyMock.anyObject(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject(), EasyMock.anyString(), EasyMock.anyObject())
+        .andReturn(SqlServerChangeTrackingMergeBatch("test", "batchId", ArcaneSchema(Seq(MergeKeyField)), "test", TablePropertiesSettings))
         .times(streamRepeatCount)
 
-      jdbcTableManager.cleanupStagingTables(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject())
+      jdbcTableManager.createStagingTable
         .andReturn(ZIO.unit)
         .anyTimes()
       jdbcTableManager.createTargetTable

--- a/src/test/scala/services/streaming/processors/MergeBatchProcessorTests.scala
+++ b/src/test/scala/services/streaming/processors/MergeBatchProcessorTests.scala
@@ -30,10 +30,10 @@ class MergeBatchProcessorTests extends AsyncFlatSpec with Matchers with EasyMock
     .takeWhile(_ < 20)
     .map { i =>
       val schema = ArcaneSchema(Seq(MergeKeyField))
-      val batch = SynapseLinkMergeBatch(s"staging_$i", schema, "target", TablePropertiesSettings)
+      val batch = SynapseLinkMergeBatch(s"staging_$i", "batch_id", schema, "target", TablePropertiesSettings)
 
       val secondSchema = ArcaneSchema(Seq(MergeKeyField, Field("field", LongType)))
-      val secondBatch = SynapseLinkMergeBatch(s"staging_0_$i", secondSchema, "target", TablePropertiesSettings)
+      val secondBatch = SynapseLinkMergeBatch(s"staging_0_$i", "batch_id", secondSchema, "target", TablePropertiesSettings)
 
       TestIndexedStagedBatches(Seq(batch, secondBatch), i)
     }

--- a/src/test/scala/services/streaming/processors/transformers/StagingProcessorTests.scala
+++ b/src/test/scala/services/streaming/processors/transformers/StagingProcessorTests.scala
@@ -42,7 +42,7 @@ class StagingProcessorTests extends AsyncFlatSpec with Matchers with EasyMockSug
     "source delete request",
   ))
 
-  it should "write data rows to single staging table" in  {
+  it should "write data rows to a single staging table" in  {
     // Arrange
     val catalogWriter = mock[CatalogWriter[RESTCatalog, Table, Schema]]
     val tableMock = mock[Table]

--- a/src/test/scala/utils/TestStagingDataSettings.scala
+++ b/src/test/scala/utils/TestStagingDataSettings.scala
@@ -5,4 +5,4 @@ import models.settings.StagingDataSettings
 object TestStagingDataSettings extends StagingDataSettings:
   override val stagingCatalogName: String = "catalog"
   override val stagingSchemaName: String = "schema"
-  override val stagingTablePrefix = "staging_"
+  override val stagingTablePrefix: String = "staging_stream_id"


### PR DESCRIPTION
Part of #89

Implemented:
- The StagingProcessor reuses the same staging table for each staged batch.
- The `batchId` property is added to each instance of th MergeableBatch trait.
- The TableManager creates the staging table on the start of the stream.