### PR TITLE
Add the graph builders for backfill streams

### DIFF
--- a/src/main/scala/services/streaming/base/BackfillStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/base/BackfillStreamingGraphBuilder.scala
@@ -1,0 +1,10 @@
+
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import zio.stream.ZStream
+
+/**
+ * A trait that represents a stream graph builder for backfilling.
+ */
+trait BackfillStreamingGraphBuilder extends StreamingGraphBuilder

--- a/src/main/scala/services/streaming/base/BackfillStreamingMergeDataProvider.scala
+++ b/src/main/scala/services/streaming/base/BackfillStreamingMergeDataProvider.scala
@@ -1,0 +1,16 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import zio.Task
+
+/**
+ * A trait that represents a backfill data provider.
+ */
+trait BackfillStreamingMergeDataProvider:
+
+  /**
+   * Provides the backfill data.
+   *
+   * @return A task that represents the backfill data.
+   */
+  def requestBackfill: Task[Unit]

--- a/src/main/scala/services/streaming/base/BackfillStreamingOverwriteDataProvider.scala
+++ b/src/main/scala/services/streaming/base/BackfillStreamingOverwriteDataProvider.scala
@@ -1,0 +1,18 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.base
+
+import services.consumers.StagedBackfillOverwriteBatch
+
+import zio.Task
+
+/**
+ * A trait that represents a backfill data provider.
+ */
+trait BackfillStreamingOverwriteDataProvider:
+
+  /**
+   * Provides the backfill data.
+   *
+   * @return A task that represents the backfill data.
+   */
+  def requestBackfill: Task[StagedBackfillOverwriteBatch]

--- a/src/main/scala/services/streaming/graph_builders/backfill/GenericBackfillMergeGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/backfill/GenericBackfillMergeGraphBuilder.scala
@@ -1,0 +1,58 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.graph_builders.backfill
+
+import services.streaming.base.{BackfillStreamingGraphBuilder, BackfillStreamingMergeDataProvider, BackfillStreamingOverwriteDataProvider, StreamDataProvider}
+import services.streaming.processors.batch_processors.backfill.BackfillApplyBatchProcessor
+
+import zio.stream.ZStream
+import zio.{ZIO, ZLayer}
+
+/**
+ * Provides the complete data stream for the streaming process including all the stages and services
+ * except the sink and lifetime service.
+ *
+ * This graph builder is used for running a backfill process when backfill behavior is set to merge.
+ * The graph builder works in the following way:
+  * 1. Runs the regular backfilling process targeting the target table.
+ *  2. Awaits the backfilling process to complete.
+ *  
+ *  This graph builder does not produce any value.
+ */
+class GenericBackfillMergeGraphBuilder(streamDataProvider: BackfillStreamingMergeDataProvider) extends BackfillStreamingGraphBuilder:
+
+  /**
+   * @inheritdoc
+   */
+  override type ProcessedBatch = Unit
+
+  /**
+   * @inheritdoc
+   */
+  override def produce: ZStream[Any, Throwable, ProcessedBatch] = ZStream.fromZIO(streamDataProvider.requestBackfill)
+
+object GenericBackfillMergeGraphBuilder:
+
+  /**
+   * The environment required for the GenericBackfillGraphBuilder.
+   */
+  type Environment = StreamDataProvider
+    & BackfillStreamingMergeDataProvider
+    & BackfillApplyBatchProcessor
+
+
+  /**
+   * Creates a new GenericBackfillGraphBuilder.
+   * @param streamDataProvider The stream data provider.
+   * @return The GenericBackfillGraphBuilder instance.
+   */
+  def apply(streamDataProvider: BackfillStreamingMergeDataProvider): GenericBackfillMergeGraphBuilder =
+    new GenericBackfillMergeGraphBuilder(streamDataProvider)
+
+  /**
+   * The ZLayer for the GenericBackfillGraphBuilder.
+   */
+  val layer: ZLayer[Environment, Nothing, BackfillStreamingGraphBuilder] =
+    ZLayer {
+      for streamDataProvider <- ZIO.service[BackfillStreamingMergeDataProvider]
+      yield GenericBackfillMergeGraphBuilder(streamDataProvider)
+    }

--- a/src/main/scala/services/streaming/graph_builders/backfill/GenericBackfillOverwriteGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/backfill/GenericBackfillOverwriteGraphBuilder.scala
@@ -1,0 +1,70 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.graph_builders.backfill
+
+import services.streaming.base.{BackfillStreamingGraphBuilder, BackfillStreamingOverwriteDataProvider, StreamDataProvider}
+
+import services.streaming.processors.batch_processors.backfill.BackfillApplyBatchProcessor
+import zio.{ZIO, ZLayer}
+import zio.stream.ZStream
+
+/**
+ * Provides the complete data stream for the streaming process including all the stages and services
+ * except the sink and lifetime service.
+ *
+ * This graph builder is used for running a backfill process when backfill behavior is set to overwrite.
+ * The graph builder works in the following way:
+ * 1. Creates the backfilling stream data provider that manages the backfilling process and produces the
+ *    mergeable batch targeting the intermediate table used as target for backfill stream.
+ * 2. Applying the resulting batch to the target table using the SQL `CREATE OR REPLACE TABLE` statement.
+ * 3. Since the table is replaced, the dispose batch processor is not needed and the graph builder.
+ */
+class GenericBackfillOverwriteGraphBuilder(streamDataProvider: BackfillStreamingOverwriteDataProvider,
+                                           applyBatchProcessor: BackfillApplyBatchProcessor)
+  extends BackfillStreamingGraphBuilder:
+
+  /**
+   * @inheritdoc
+   */
+  override type ProcessedBatch = BackfillApplyBatchProcessor#BatchType
+
+  /**
+   * @inheritdoc
+   */
+  override def produce: ZStream[Any, Throwable, ProcessedBatch] =
+    ZStream.fromZIO(streamDataProvider.requestBackfill).via(applyBatchProcessor.process)
+
+object GenericBackfillOverwriteGraphBuilder:
+
+  /**
+   * The environment required for the GenericBackfillGraphBuilder.
+   */
+  type Environment = StreamDataProvider
+    & BackfillStreamingOverwriteDataProvider
+    & BackfillApplyBatchProcessor
+
+
+  /**
+   * Creates a new GenericBackfillGraphBuilder.
+   * @param streamDataProvider The stream data provider.
+   * @param fieldFilteringProcessor The field filtering processor.
+   * @param groupTransformer The group transformer.
+   * @param stagingProcessor The staging processor.
+   * @param mergeProcessor The merge processor.
+   * @param disposeBatchProcessor The dispose batch processor.
+   * @param hookManager The hook manager.
+   * @return The GenericBackfillGraphBuilder instance.
+   */
+  def apply(streamDataProvider: BackfillStreamingOverwriteDataProvider,
+            mergeBatchProcessor: BackfillApplyBatchProcessor): GenericBackfillOverwriteGraphBuilder =
+    new GenericBackfillOverwriteGraphBuilder(streamDataProvider, mergeBatchProcessor)
+
+  /**
+   * The ZLayer for the GenericBackfillGraphBuilder.
+   */
+  val layer: ZLayer[Environment, Nothing, BackfillStreamingGraphBuilder] =
+    ZLayer {
+      for
+        streamDataProvider <- ZIO.service[BackfillStreamingOverwriteDataProvider]
+        mergeProcessor <- ZIO.service[BackfillApplyBatchProcessor]
+      yield GenericBackfillOverwriteGraphBuilder(streamDataProvider, mergeProcessor)
+    }


### PR DESCRIPTION
This PR adds the stream graph builders for both `merge` and `overwrite` behaviors in backfill mode.