### PR TITLE
Convert the default log annotations to snake case

### DIFF
--- a/src/main/scala/extensions/StringExtensions.scala
+++ b/src/main/scala/extensions/StringExtensions.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package extensions
+
+/**
+ * String extension methods for various utility functions.
+ */
+object StringExtensions:
+
+  /**
+   * Converts a string from camelCase to snake_case.
+   *
+   * @param str The input string in camelCase format.
+   * @return The converted string in snake_case format.
+   */
+  extension (str: String) def camelCaseToSnakeCase: String = str
+    .replaceAll("([a-z])([A-Z])", "$1_$2")
+    .toLowerCase()

--- a/src/main/scala/logging/ZIOLogAnnotations.scala
+++ b/src/main/scala/logging/ZIOLogAnnotations.scala
@@ -52,7 +52,7 @@ object ZIOLogAnnotations:
   private def defaultsWithTemplate(template: String): Seq[(LogAnnotation[String], String)] =
     defaults ++ Seq((getStringAnnotation(name = "messageTemplate"), template))
 
-  
+
   /**
    * Log using default annotations
    *

--- a/src/main/scala/logging/ZIOLogAnnotations.scala
+++ b/src/main/scala/logging/ZIOLogAnnotations.scala
@@ -7,6 +7,7 @@ import upickle.default.read
 import zio.stream.ZStream
 
 import scala.annotation.unused
+import extensions.StringExtensions.camelCaseToSnakeCase
 
 
 /**
@@ -43,15 +44,15 @@ object ZIOLogAnnotations:
   final def getAnnotation(name: String, value: String): (LogAnnotation[String], String) = (getStringAnnotation(name), value)
 
   private val defaults: Seq[(LogAnnotation[String], String)] = Seq(
-    (getStringAnnotation(name = "streamKind"), streamClass),
-    (getStringAnnotation(name = "streamId"), streamId),
-    (getStringAnnotation(name = "ApplicationVersion"), streamVersion)
+    (getStringAnnotation(name = "streamKind"), streamClass.camelCaseToSnakeCase),
+    (getStringAnnotation(name = "streamId"), streamId.camelCaseToSnakeCase),
+    (getStringAnnotation(name = "ApplicationVersion"), streamVersion.camelCaseToSnakeCase)
   ) ++ read[Map[String, String]](streamExtraProperties).map { (key, value) => (getStringAnnotation(key), value) }
 
   private def defaultsWithTemplate(template: String): Seq[(LogAnnotation[String], String)] =
     defaults ++ Seq((getStringAnnotation(name = "messageTemplate"), template))
 
-
+  
   /**
    * Log using default annotations
    *

--- a/src/main/scala/logging/ZIOLogAnnotations.scala
+++ b/src/main/scala/logging/ZIOLogAnnotations.scala
@@ -20,20 +20,17 @@ object ZIOLogAnnotations:
   /**
    * Stream class. This value is provided by the Arcane Operator using the `STREAMCONTEXT__STREAM_KIND` environment variable
    * and matches the .kind field of the custom resource used to create the stream.
-   * @note This is used for logging and changes in this value must be reflected in the stream class in the dashboard.
    */
   private lazy val streamClass = sys.env.getOrElse("STREAMCONTEXT__STREAM_KIND", "undefined")
 
   /**
    * Stream identifier. This value is provided by the Arcane Operator using the `STREAMCONTEXT__STREAM_ID` environment variable
    * and matches the .metadata.name field of the custom resource used to create the stream.
-   * @note This is used for logging and changes in this value must be reflected in the stream name in the dashboard.
    */
   private lazy val streamId = sys.env.getOrElse("STREAMCONTEXT__STREAM_ID", "undefined")
 
   /**
    * Version of the application. This value should be defined in the stream job template for the stream.
-   * @note This is used for logging and changes in this value must be reflected in the application version in the dashboard.
    */
   private lazy val streamVersion = sys.env.getOrElse("APPLICATION_VERSION", "0.0.0")
 
@@ -45,7 +42,7 @@ object ZIOLogAnnotations:
 
   /**
    * Application name
-   * @note This is used for logging and changes in this value must be reflected in the application name in the dashboard.
+   * @note This is used for logging and should contain the same value for all streams.
    */
   private lazy val applicationName = "Arcane.Stream"
 

--- a/src/main/scala/logging/ZIOLogAnnotations.scala
+++ b/src/main/scala/logging/ZIOLogAnnotations.scala
@@ -16,10 +16,38 @@ import extensions.StringExtensions.camelCaseToSnakeCase
  */
 @unused
 object ZIOLogAnnotations:
+
+  /**
+   * Stream class. This value is provided by the Arcane Operator using the `STREAMCONTEXT__STREAM_KIND` environment variable
+   * and matches the .kind field of the custom resource used to create the stream.
+   * @note This is used for logging and changes in this value must be reflected in the stream class in the dashboard.
+   */
   private lazy val streamClass = sys.env.getOrElse("STREAMCONTEXT__STREAM_KIND", "undefined")
+
+  /**
+   * Stream identifier. This value is provided by the Arcane Operator using the `STREAMCONTEXT__STREAM_ID` environment variable
+   * and matches the .metadata.name field of the custom resource used to create the stream.
+   * @note This is used for logging and changes in this value must be reflected in the stream name in the dashboard.
+   */
   private lazy val streamId = sys.env.getOrElse("STREAMCONTEXT__STREAM_ID", "undefined")
+
+  /**
+   * Version of the application. This value should be defined in the stream job template for the stream.
+   * @note This is used for logging and changes in this value must be reflected in the application version in the dashboard.
+   */
   private lazy val streamVersion = sys.env.getOrElse("APPLICATION_VERSION", "0.0.0")
+
+  /**
+   * Extra properties to be added to the log
+   * @note This is a JSON string with key-value pairs. For example: {"key1": "value1", "key2": "value2"}
+   */
   private lazy val streamExtraProperties = sys.env.getOrElse("ARCANE__LOGGING_PROPERTIES", "{}")
+
+  /**
+   * Application name
+   * @note This is used for logging and changes in this value must be reflected in the application name in the dashboard.
+   */
+  private lazy val applicationName = "Arcane.Stream"
 
   private def logEnriched(initial: zio.UIO[Unit], extra: Seq[(LogAnnotation[String], String)]) = extra
     .map { (annotation, value) => annotation(value) }
@@ -46,7 +74,8 @@ object ZIOLogAnnotations:
   private val defaults: Seq[(LogAnnotation[String], String)] = Seq(
     (getStringAnnotation(name = "streamKind"), streamClass.camelCaseToSnakeCase),
     (getStringAnnotation(name = "streamId"), streamId.camelCaseToSnakeCase),
-    (getStringAnnotation(name = "ApplicationVersion"), streamVersion.camelCaseToSnakeCase)
+    (getStringAnnotation(name = "ApplicationVersion"), streamVersion),
+    (getStringAnnotation(name = "Application"), applicationName)
   ) ++ read[Map[String, String]](streamExtraProperties).map { (key, value) => (getStringAnnotation(key), value) }
 
   private def defaultsWithTemplate(template: String): Seq[(LogAnnotation[String], String)] =

--- a/src/test/scala/extensions/StringExtensionTests.scala
+++ b/src/test/scala/extensions/StringExtensionTests.scala
@@ -1,0 +1,35 @@
+package com.sneaksanddata.arcane.framework
+package extensions
+
+import extensions.StringExtensions.camelCaseToSnakeCase
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks.*
+
+
+class StringExtensionTests extends AnyFlatSpec with Matchers:
+
+  private val testCases = Table(
+    ("string", "expectedResult"),
+    ("abc", "abc"),
+    ("ABC", "abc"),
+    ("aBc", "a_bc"),
+    ("AbcdeFgh", "abcde_fgh"),
+    ("_AbcdeFgh_", "_abcde_fgh_"),
+    ("___", "___"),
+    ("AaBbCcDd", "aa_bb_cc_dd"),
+    ("MicrosoftSqlServerStream", "microsoft_sql_server_stream"),
+    ("MicrosoftSynapseStream", "microsoft_synapse_stream"),
+    ("Abcde-Fgh", "abcde-fgh"),
+    ("A-_-bcde-Fgh", "a-_-bcde-fgh"),
+    ("v0.1.2.3", "v0.1.2.3"),
+  )
+
+  it should "convert camel case to snakeCase" in {
+    forAll (testCases) { (string, expected) =>
+      val result = string.camelCaseToSnakeCase
+      result should equal(expected)
+    }
+  }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-stream-sqlserver-change-tracking/issues/142

## Scope
This is small change related to metrics and logs collection: convert all camel-case values to snake case to improve readability in datadog.

## Additional changes
Added the `Application` property to logs and added documentation for default log annotations.