### PR TITLE
Use parallel collections when grouping rows by schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val root = (project in file("."))
     libraryDependencies += "com.microsoft.sqlserver" % "mssql-jdbc" % "12.8.1.jre11",
     libraryDependencies += "software.amazon.awssdk" % "s3" % "2.29.52",
     libraryDependencies += "com.lihaoyi" %% "upickle" % "4.0.2",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
 
     // https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-api
     libraryDependencies += "org.apache.iceberg" % "iceberg-api" % "1.8.1",

--- a/src/main/scala/utils/CollectionUtils.scala
+++ b/src/main/scala/utils/CollectionUtils.scala
@@ -1,0 +1,29 @@
+package com.sneaksanddata.arcane.framework
+package utils
+
+import models.DataRow
+import zio.Chunk
+
+/**
+ * Utility functions for Scala collections
+ */
+object CollectionUtils:
+
+  /**
+   * Merges to maps containing ZIO chunks as values
+   * @param mapA First map
+   * @param mapB Second map
+   * @tparam K Map key type
+   * @tparam V Chunk value type
+   * @return A map of K, Chunk[V], containing keys from mapA and mapB (merged), and for intersecting keys their respective values are also merged into a new collection.
+   */
+  def mergeGroupedChunks[K, V](mapA: Map[K, Chunk[V]], mapB: Map[K, Chunk[V]]): Map[K, Chunk[V]] =
+    (mapA.toSeq ++ mapB).groupMap(_._1)(_._2).map {
+      case (key, chunks) => key -> Chunk.from(chunks.flatten)
+    }
+
+  /**
+   * Converts a grouped data row to a single-value map, with row itself wrapped in ZIO chunk.
+    */
+  extension[K] (enrichedRow: (K, DataRow)) def toChunkMap: Map[K, Chunk[DataRow]] =
+    Map(enrichedRow._1 -> Chunk(enrichedRow._2))


### PR DESCRIPTION
## Scope
- Improve row grouping performance (by schema) by performing the grouping operating using `.par` (Scala parallel collections)

This addresses performance degradation when loading very wide tables (250+ columns). However, this is more of a bandaid rather than a proper fix. For example, SQL server streams do not require this operation at all, since they can only emit a single schema.
In general, framework should handle this and ideally not require schema grouping for sources that emit single schema only.