### PR TITLE
Use unbounded buffering to increase processing throughput

### DIFF
--- a/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
@@ -32,7 +32,9 @@ class GenericStreamingGraphBuilder(streamDataProvider: StreamDataProvider,
    */
   override def produce(hookManager: HookManager): ZStream[Any, Throwable, ProcessedBatch] =
     streamDataProvider.stream
-      .via(fieldFilteringProcessor.process)
+      // TODO: test performance w/o field filters
+      //.via(fieldFilteringProcessor.process)
+      // TODO: field filters should be applied conditionally, if indeed this is not a no-op pipeline
       .via(groupTransformer.process)
       .via(stagingProcessor.process(hookManager.onStagingTablesComplete, hookManager.onBatchStaged))
       .via(mergeProcessor.process)

--- a/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
@@ -32,9 +32,8 @@ class GenericStreamingGraphBuilder(streamDataProvider: StreamDataProvider,
    */
   override def produce(hookManager: HookManager): ZStream[Any, Throwable, ProcessedBatch] =
     streamDataProvider.stream
-      // TODO: test performance w/o field filters
-      //.via(fieldFilteringProcessor.process)
-      // TODO: field filters should be applied conditionally, if indeed this is not a no-op pipeline
+      .bufferUnbounded
+      .via(fieldFilteringProcessor.process)
       .via(groupTransformer.process)
       .via(stagingProcessor.process(hookManager.onStagingTablesComplete, hookManager.onBatchStaged))
       .via(mergeProcessor.process)

--- a/src/main/scala/services/streaming/processors/transformers/FieldFilteringTransformer.scala
+++ b/src/main/scala/services/streaming/processors/transformers/FieldFilteringTransformer.scala
@@ -20,8 +20,7 @@ class FieldFilteringTransformer(fieldsFilteringService: FieldsFilteringService) 
    * @inheritdoc
    */
   override def process: ZPipeline[Any, Throwable, Element, Element] = ZPipeline.map {
-    case row: DataRow => fieldsFilteringService.filter(row)
-    case other: Any => other
+    fieldsFilteringService.filter(_: DataRow)
   }
 
 /**


### PR DESCRIPTION
## Scope
- Add `.bufferUnbounded` to the staging processor - allowing data provider to keep feeding rows while the batch is merged