### PR TITLE
Allow setting fetch size for SQL streams

### DIFF
--- a/src/main/resources/get_select_all_query_date_partitioned.sql
+++ b/src/main/resources/get_select_all_query_date_partitioned.sql
@@ -1,8 +1,0 @@
-declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
-
-SELECT
-{ChangeTrackingColumnsStatement},
-@currentVersion AS 'ChangeTrackingVersion',
-lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}],
-{DATE_PARTITION_EXPRESSION} as [{DATE_PARTITION_KEY}]
-FROM [{dbName}].[{schema}].[{tableName}] tq

--- a/src/main/resources/get_select_delta_query_date_partitioned.sql
+++ b/src/main/resources/get_select_delta_query_date_partitioned.sql
@@ -1,9 +1,0 @@
-declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
-
-SELECT
-{ChangeTrackingColumnsStatement},
-@currentVersion AS 'ChangeTrackingVersion',
-lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}],
-{DATE_PARTITION_EXPRESSION} as [{DATE_PARTITION_KEY}]
-FROM [{dbName}].[{schema}].[{tableName}] tq
-RIGHT JOIN (SELECT ct.* FROM CHANGETABLE (CHANGES [{dbName}].[{schema}].[{tableName}], {lastId}) ct ) ct ON {ChangeTrackingMatchStatement}

--- a/src/main/scala/services/mssql/MsSqlConnection.scala
+++ b/src/main/scala/services/mssql/MsSqlConnection.scala
@@ -234,8 +234,8 @@ object MsSqlConnection:
    * returned by the query if the result set is being closed without cancelling the statement first.
    * see: https://github.com/microsoft/mssql-jdbc/issues/877 for details.
    * ALL RESULT SETS CREATED FROM MS SQL CONNECTION MUST BE CLOSED THIS WAY
-   * resultSet The result set to close.
-   * statement The statement to close.
+   * @param resultSet The result set to close.
+   * @param statement The statement to close.
    * @return UIO[Unit] that completes when the result set is closed.
    */
   extension (resultSet: ResultSet) def closeSafe(statement: Statement): UIO[Unit] =

--- a/src/main/scala/services/mssql/QueryProvider.scala
+++ b/src/main/scala/services/mssql/QueryProvider.scala
@@ -22,7 +22,7 @@ object QueryProvider:
   /**
    * Gets the schema query for the Microsoft SQL Server database.
    *
-   * @param msSqlConnection The connection to the database.
+   * msSqlConnection The connection to the database.
    * @return A future containing the schema query for the Microsoft SQL Server database.
    */
   extension (msSqlConnection: MsSqlConnection) def getSchemaQuery: Task[MsSqlQuery] =
@@ -153,10 +153,7 @@ object QueryProvider:
                               changeTrackingId: Long): Task[MsSqlQuery] =
     ZIO.scoped {
       for querySource <- ZIO.fromAutoCloseable {
-            connectionOptions.partitionExpression match {
-              case Some(_) => ZIO.attempt(Source.fromResource("get_select_delta_query_date_partitioned.sql"))
-              case None => ZIO.attempt(Source.fromResource("get_select_delta_query.sql"))
-            }
+            ZIO.attempt(Source.fromResource("get_select_delta_query.sql"))
           }
           baseQuery <- ZIO.attempt(querySource.getLines.mkString("\n"))
           query = baseQuery.replace("{dbName}", databaseName)
@@ -166,8 +163,6 @@ object QueryProvider:
             .replace("{ChangeTrackingMatchStatement}", matchStatement)
             .replace("{MERGE_EXPRESSION}", mergeExpression)
             .replace("{MERGE_KEY}", MergeKeyField.name)
-            .replace("{DATE_PARTITION_EXPRESSION}", connectionOptions.partitionExpression.getOrElse(""))
-            .replace("{DATE_PARTITION_KEY}", DatePartitionField.name)
             .replace("{lastId}", changeTrackingId.toString)
       yield query
     }
@@ -178,10 +173,7 @@ object QueryProvider:
                           columnExpression: String): Task[MsSqlQuery] =
     ZIO.scoped {
       for querySource <- ZIO.fromAutoCloseable {
-            connectionOptions.partitionExpression match {
-              case Some(_) => ZIO.attempt(Source.fromResource("get_select_all_query_date_partitioned.sql"))
-              case None => ZIO.attempt(Source.fromResource("get_select_all_query.sql"))
-            }
+            ZIO.attempt(Source.fromResource("get_select_all_query.sql"))
           }
           baseQuery <- ZIO.attempt(querySource.getLines.mkString("\n"))
           query = baseQuery
@@ -191,7 +183,5 @@ object QueryProvider:
             .replace("{ChangeTrackingColumnsStatement}", columnExpression)
             .replace("{MERGE_EXPRESSION}", mergeExpression)
             .replace("{MERGE_KEY}", MergeKeyField.name)
-            .replace("{DATE_PARTITION_EXPRESSION}", connectionOptions.partitionExpression.getOrElse(""))
-            .replace("{DATE_PARTITION_KEY}", DatePartitionField.name)
       yield query
     }

--- a/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -152,8 +152,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
       Field("b", TimestampType),
       Field("cd", IntType),
       Field("ChangeTrackingVersion", LongType),
-      MergeKeyField,
-      Field("DATE_PARTITION_KEY", StringType))
+      MergeKeyField)
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(connection.getSchema)) map { schema =>
       val fields = for column <- schema if column.isInstanceOf[ArcaneSchemaField] yield column
       fields should be(expected)
@@ -177,7 +176,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
         result <- connection.backfill.runCollect
         head = result.head
     yield {
-      head should have length 11
+      head should have length 10
     }
     
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(task))

--- a/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -108,7 +108,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     val connector = MsSqlConnection(dbInfo.connectionOptions)
     val task = QueryProvider.getSchemaQuery(connector) map { query =>
       query should (
-        include ("ct.SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY") and include("format(getdate(), 'yyyyMM')")
+        include ("ct.SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY")
         )
     }
     
@@ -133,7 +133,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     val connector = MsSqlConnection(dbInfo.connectionOptions)
     val task = QueryProvider.getBackfillQuery(connector) map { query =>
       query should (
-        include ("SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY") and include("format(getdate(), 'yyyyMM')")
+        include ("SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY")
         )
     }
     

--- a/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -40,7 +40,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
         connectionUrl,
         "dbo",
         tableName,
-        Some("format(getdate(), 'yyyyMM')")), con)
+        None), con)
 
   def createTable(tableName: String, con: Connection): Unit =
     val query = s"use arcane; drop table if exists dbo.$tableName; create table dbo.$tableName (x int not null, y int, z DECIMAL(30, 6), a VARBINARY(MAX), b DATETIME, [c/d] int)"

--- a/src/test/scala/services/connectors/mssql/MsSqlDataProviderTests.scala
+++ b/src/test/scala/services/connectors/mssql/MsSqlDataProviderTests.scala
@@ -49,7 +49,7 @@ class MsSqlDataProviderTests extends flatspec.AsyncFlatSpec with Matchers:
         connectionUrl,
         "dbo",
         tableName,
-        Some("format(getdate(), 'yyyyMM')")), con)
+        None), con)
 
   def createTable(tableName: String, con: Connection): Unit =
     val query = s"use arcane; drop table if exists dbo.$tableName; create table dbo.$tableName (x int not null, y int)"


### PR DESCRIPTION
## Scope
- Utilize `setFetchSize` to increase throughput and expose it via connection options
- Minor refactoring
- Remove `DATE_PARTITION_FIELD` etc since deprecated