### PR TITLE
Implement ability to override source buffering settings for the stream

### DIFF
--- a/src/main/scala/models/settings/SourceBufferingSettings.scala
+++ b/src/main/scala/models/settings/SourceBufferingSettings.scala
@@ -14,7 +14,7 @@ enum BufferingStrategy:
    * Buffers the data in memory in bounded queue with a limited size. If the queue is full, the stream will block
    * the upstream until space is available.
    */
-  case Buffering
+  case Buffering(maxBufferSize: Int)
 
 /**
  * Provides settings for source buffering in the streaming process.
@@ -34,8 +34,3 @@ trait SourceBufferingSettings:
    * Indicates whether buffering is enabled.
    */
   val bufferingEnabled: Boolean
-
-  /**
-   * The maximum number of rows to buffer in memory.
-   */
-  val maxBufferSize: Int

--- a/src/main/scala/models/settings/SourceBufferingSettings.scala
+++ b/src/main/scala/models/settings/SourceBufferingSettings.scala
@@ -1,0 +1,41 @@
+package com.sneaksanddata.arcane.framework
+package models.settings
+
+/**
+ * Provides buffering strategies for the streaming process.
+ */
+enum BufferingStrategy:
+  /**
+   * Buffers the data in memory in unbounded queue.
+   */
+  case Unbounded
+
+  /**
+   * Buffers the data in memory in bounded queue with a limited size. If the queue is full, the stream will block
+   * the upstream until space is available.
+   */
+  case Buffering
+
+/**
+ * Provides settings for source buffering in the streaming process.
+ * Allows a faster producer to progress independently of a slower consumer by buffering up
+ * to capacity elements in a queue.
+ *
+ * The buffering settings are applied to the data provider to allow the data provider and the later
+ * stages of the pipeline run asynchronously.
+ */
+trait SourceBufferingSettings:
+  /**
+   * The buffering strategy to use.
+   */
+  val bufferingStrategy: BufferingStrategy
+
+  /**
+   * Indicates whether buffering is enabled.
+   */
+  val bufferingEnabled: Boolean
+
+  /**
+   * The maximum number of rows to buffer in memory.
+   */
+  val maxBufferSize: Int

--- a/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
+++ b/src/main/scala/services/streaming/graph_builders/GenericStreamingGraphBuilder.scala
@@ -57,9 +57,8 @@ object GenericStreamingGraphBuilder:
         case (true, BufferingStrategy.Unbounded)
           => zlogStream("Running stream with unbound source buffer") *> stream.bufferUnbounded
         
-        case (true, BufferingStrategy.Buffering)
-          => zlogStream("Running stream with bound source buffer with size %s", settings.maxBufferSize.toString)
-              *> stream.buffer(settings.maxBufferSize)
+        case (true, BufferingStrategy.Buffering(size))
+          => zlogStream("Running stream with bound source buffer size %s", size.toString) *> stream.buffer(size)
         
         case (false, _)
           => zlogStream("Running stream with disabled source buffering") *> stream

--- a/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
+++ b/src/test/scala/services/streaming/GenericStreamRunnerServiceTests.scala
@@ -16,13 +16,14 @@ import services.streaming.processors.transformers.FieldFilteringTransformer.Envi
 import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 import services.streaming.processors.utils.TestIndexedStagedBatches
 import utils.*
-
 import models.app.StreamContext
 import services.lakehouse.{IcebergCatalogCredential, IcebergS3CatalogWriter}
 import services.mssql.MssqlBackfillDataProvider
 import services.streaming.graph_builders.GenericStreamingGraphBuilder
 import services.streaming.graph_builders.backfill.GenericBackfillOverwriteGraphBuilder
-import tests.shared.IcebergCatalogInfo._
+import tests.shared.IcebergCatalogInfo.*
+
+import com.sneaksanddata.arcane.framework.models.settings.{BufferingStrategy, SourceBufferingSettings}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import org.easymock.EasyMock
@@ -112,7 +113,8 @@ class GenericStreamRunnerServiceTests extends AsyncFlatSpec with Matchers with E
       ZLayer.succeed(streamDataProvider),
       ZLayer.succeed(new StreamContext {
         override def IsBackfilling: Boolean = false
-      })
+      }),
+      ZLayer.succeed(TestSourceBufferingSettings),
     )
 
     // Act

--- a/src/test/scala/services/streaming/data_providers/backfill/GenericBackfillStreamingMergeDataProviderTests.scala
+++ b/src/test/scala/services/streaming/data_providers/backfill/GenericBackfillStreamingMergeDataProviderTests.scala
@@ -15,10 +15,11 @@ import services.streaming.processors.batch_processors.streaming.{DisposeBatchPro
 import services.streaming.processors.transformers.FieldFilteringTransformer.Environment
 import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 import services.streaming.processors.utils.TestIndexedStagedBatches
-import tests.shared.IcebergCatalogInfo._
+import tests.shared.IcebergCatalogInfo.*
 import utils.*
-
 import services.lakehouse.{IcebergCatalogCredential, IcebergS3CatalogWriter}
+
+import com.sneaksanddata.arcane.framework.models.settings.{BufferingStrategy, SourceBufferingSettings}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import org.easymock.EasyMock
@@ -158,7 +159,8 @@ class GenericBackfillStreamingMergeDataProviderTests extends AsyncFlatSpec with 
       ZLayer.succeed(streamDataProvider),
       ZLayer.succeed(new StreamContext {
         override def IsBackfilling: Boolean = false
-      })
+      }),
+      ZLayer.succeed(TestSourceBufferingSettings),
     )
 
     // Act

--- a/src/test/scala/services/streaming/data_providers/backfill/GenericBackfillStreamingOverwriteDataProviderTests.scala
+++ b/src/test/scala/services/streaming/data_providers/backfill/GenericBackfillStreamingOverwriteDataProviderTests.scala
@@ -17,11 +17,12 @@ import services.streaming.processors.batch_processors.streaming.{DisposeBatchPro
 import services.streaming.processors.transformers.FieldFilteringTransformer.Environment
 import services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 import services.streaming.processors.utils.TestIndexedStagedBatches
-import tests.shared.IcebergCatalogInfo._
+import tests.shared.IcebergCatalogInfo.*
 import utils.*
-
 import services.lakehouse.{IcebergCatalogCredential, IcebergS3CatalogWriter}
 import utils.TestBackfillTableSettings
+
+import com.sneaksanddata.arcane.framework.models.settings.{BufferingStrategy, SourceBufferingSettings}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import org.easymock.EasyMock
@@ -181,7 +182,8 @@ class GenericBackfillStreamingOverwriteDataProviderTests extends AsyncFlatSpec w
       ZLayer.succeed(streamDataProvider),
       ZLayer.succeed(new StreamContext {
         override def IsBackfilling: Boolean = false
-      })
+      }),
+      ZLayer.succeed(TestSourceBufferingSettings),
     )
 
     // Act

--- a/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
+++ b/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
@@ -11,7 +11,7 @@ import com.sneaksanddata.arcane.framework.services.streaming.processors.GenericG
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.backfill.BackfillApplyBatchProcessor
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
-import com.sneaksanddata.arcane.framework.utils.CustomTestBackfillTableSettings
+import com.sneaksanddata.arcane.framework.utils.{CustomTestBackfillTableSettings, TestGroupingSettings}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
@@ -56,7 +56,8 @@ class GenericGraphBuilderFactoryTests extends AsyncFlatSpec with Matchers with E
           ZLayer.succeed(mock[GenericGroupingTransformer]),
           ZLayer.succeed(mock[MergeBatchProcessor]),
           ZLayer.succeed(mock[DisposeBatchProcessor]),
-          ZLayer.succeed(mock[BackfillStreamingOverwriteDataProvider])
+          ZLayer.succeed(mock[BackfillStreamingOverwriteDataProvider]),
+          ZLayer.succeed(TestGroupingSettings)
         )
       
       val getResolvedClassName = service.map(_.getClass.getName.split('.').last)

--- a/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
+++ b/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.streaming.graph_builders
 
 import com.sneaksanddata.arcane.framework.models.app.StreamContext
-import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings}
+import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings, BufferingStrategy, SourceBufferingSettings}
 import com.sneaksanddata.arcane.framework.services.app.base.StreamLifetimeService
 import com.sneaksanddata.arcane.framework.services.streaming.base.{BackfillStreamingMergeDataProvider, BackfillStreamingOverwriteDataProvider, HookManager, StreamDataProvider, StreamingGraphBuilder}
 import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.backfill.{GenericBackfillMergeGraphBuilder, GenericBackfillOverwriteGraphBuilder}
@@ -57,7 +57,7 @@ class GenericGraphBuilderFactoryTests extends AsyncFlatSpec with Matchers with E
           ZLayer.succeed(mock[MergeBatchProcessor]),
           ZLayer.succeed(mock[DisposeBatchProcessor]),
           ZLayer.succeed(mock[BackfillStreamingOverwriteDataProvider]),
-          ZLayer.succeed(TestGroupingSettings)
+          ZLayer.succeed(TestSourceBufferingSettings),
         )
       
       val getResolvedClassName = service.map(_.getClass.getName.split('.').last)

--- a/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
+++ b/src/test/scala/services/streaming/graph_builders/GenericGraphBuilderFactoryTests.scala
@@ -18,6 +18,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import org.scalatestplus.easymock.EasyMockSugar
 import zio.{Runtime, Unsafe, ZIO, ZLayer}
+import com.sneaksanddata.arcane.framework.utils.TestSourceBufferingSettings
 
 class GenericGraphBuilderFactoryTests extends AsyncFlatSpec with Matchers with EasyMockSugar:
   private val runtime = Runtime.default

--- a/src/test/scala/utils/TestSourceBufferingSettings.scala
+++ b/src/test/scala/utils/TestSourceBufferingSettings.scala
@@ -1,0 +1,9 @@
+package com.sneaksanddata.arcane.framework
+package utils
+
+import models.settings.{SourceBufferingSettings, BufferingStrategy}
+
+object TestSourceBufferingSettings extends SourceBufferingSettings:
+  override val bufferingStrategy: BufferingStrategy = BufferingStrategy.Unbounded
+  override val bufferingEnabled: Boolean = true
+  override val maxBufferSize: Int = 0

--- a/src/test/scala/utils/TestSourceBufferingSettings.scala
+++ b/src/test/scala/utils/TestSourceBufferingSettings.scala
@@ -6,4 +6,3 @@ import models.settings.{SourceBufferingSettings, BufferingStrategy}
 object TestSourceBufferingSettings extends SourceBufferingSettings:
   override val bufferingStrategy: BufferingStrategy = BufferingStrategy.Unbounded
   override val bufferingEnabled: Boolean = true
-  override val maxBufferSize: Int = 0


### PR DESCRIPTION
This PR introduces a new settings set for stream graph builder which allows to overwrite source buffering to allow to manage trade-offs between the stream throughput and latency/memory consumption.

The trait `SourceBufferingSettings` allows to set the following buffering strategies
- `Unbounded` (default for backfills)
- `Buffering(size: int)` (fixed-size buffer with back pressure)

The default implementation to be provided by the streaming plugin is the following:
- In case of backfill buffering is enabled with the `Unbounded` strategy.
- In case of streaming, buffering is disabled, but the StreamContext allows to override settings.