### PR TITLE
Remove the changeCapturePeriod from VersionedDataGraphBuilderSettings

### DIFF
--- a/src/main/scala/models/settings/VersionedDataGraphBuilderSettings.scala
+++ b/src/main/scala/models/settings/VersionedDataGraphBuilderSettings.scala
@@ -6,7 +6,7 @@ import java.time.Duration
 /**
  * Provides settings for a stream source.
  */
-trait VersionedDataGraphBuilderSettings {
+trait VersionedDataGraphBuilderSettings:
 
   /**
    * The interval to look back for changes on the startup of the stream.
@@ -17,9 +17,3 @@ trait VersionedDataGraphBuilderSettings {
    * The interval for periodic change capture operation.
    */
   val changeCaptureInterval: Duration
-  
-  /**
-   * The interval to look back for changes on each iteration of the stream.
-   */
-  val changeCapturePeriod: Duration
-}

--- a/src/test/scala/services/connectors/mssql/MsSqlDataProviderTests.scala
+++ b/src/test/scala/services/connectors/mssql/MsSqlDataProviderTests.scala
@@ -33,7 +33,6 @@ class MsSqlDataProviderTests extends flatspec.AsyncFlatSpec with Matchers:
   private val settings = new VersionedDataGraphBuilderSettings {
     override val lookBackInterval: Duration = Duration.ofHours(1)
     override val changeCaptureInterval: Duration = Duration.ofMillis(1)
-    override val changeCapturePeriod: Duration = Duration.ofHours(1)
   }
   
   private val emptyFieldsFilteringService: MsSqlServerFieldsFilteringService = (fields: List[ColumnSummary]) => Success(fields)

--- a/src/test/scala/tests/synapse/SynapseLinkStreamingDataProviderTests.scala
+++ b/src/test/scala/tests/synapse/SynapseLinkStreamingDataProviderTests.scala
@@ -21,7 +21,6 @@ object SynapseLinkStreamingDataProviderTests extends ZIOSpecDefault:
   private val graphSettings = new VersionedDataGraphBuilderSettings {
     override val lookBackInterval: Duration = Duration.ofHours(3)
     override val changeCaptureInterval: Duration = Duration.ofSeconds(5)
-    override val changeCapturePeriod: Duration = Duration.ofHours(1)
   }
   private val backfillSettings = new BackfillSettings {
     override val backfillBehavior: BackfillBehavior = Overwrite


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-stream-microsoft-synapse-link/pull/136

We need to remove this field from framework to be able to remove it from MS Synapse CRD