### PR TITLE
Replace LazyList with an Iterator to address memory pressure

### DIFF
--- a/src/main/scala/services/mssql/MsSqlDataProvider.scala
+++ b/src/main/scala/services/mssql/MsSqlDataProvider.scala
@@ -18,7 +18,7 @@ given HasVersion[VersionedBatch] with
   private val partial: PartialFunction[VersionedBatch, Option[Long]] =
     case (queryResult, version: Long) =>
       // If the database response is empty, we can't extract the version from it and return the old version.
-      queryResult.read.headOption match
+      queryResult.read.nextOption() match
         case None      => Some(version)
         case Some(row) =>
           // If the database response is not empty, we can extract the version from any row of the response.


### PR DESCRIPTION
## Scope

- Replace LazyList with a custom Iterator to avoid memory buildup when a query returns high number of rows

Final fix is to convert to ZIO: https://github.com/SneaksAndData/arcane-framework-scala/pull/171, however it takes a bit more time to get that one done, so let's hotifx for now.