### PR TITLE
[Parquet Source] Add S3 Blob Reader Implementation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,7 +54,20 @@ services:
       - |
         mc alias set e2e "http://localhost:9000" minioadmin minioadmin
         mc admin info e2e
-        mc mb e2e/tmp && mc mb e2e/lakehouse
+        mc mb --ignore-existing e2e/tmp && mc mb --ignore-existing e2e/lakehouse && mc mb --ignore-existing e2e/s3-blob-reader
+  s3_reader_prepare:
+    image: python:3.11-slim-bookworm
+    network_mode: host
+    environment:
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - AWS_ENDPOINT_URL_S3=http://localhost:9000
+    depends_on:
+      - prepare_buckets
+    restart: "no"
+    volumes:
+      - ./populate-s3-reader-bucket.py:/populate-s3-reader-bucket.py
+    command: [ "/bin/sh", "-c", "pip install boto3 pandas pyarrow fastparquet && python /populate-s3-reader-bucket.py"  ]
   # https://github.com/databricks/docker-spark-iceberg/blob/main/docker-compose.yml
   lakekeeper:
     image: quay.io/lakekeeper/catalog:v0.9.2

--- a/populate-s3-reader-bucket.py
+++ b/populate-s3-reader-bucket.py
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import pandas as pd
+import string
+import random
+import os
+import boto3
+
+def upload_file(file_name, bucket, object_name=None):
+    """Upload a file to an S3 bucket
+
+    :param file_name: File to upload
+    :param bucket: Bucket to upload to
+    :param object_name: S3 object name. If not specified then file_name is used
+    :return: True if file was uploaded, else False
+    """
+
+    # If S3 object_name was not specified, use file_name
+    if object_name is None:
+        object_name = os.path.basename(file_name)
+
+    # Upload the file
+    s3_client = boto3.client('s3')
+    _ = s3_client.upload_file(file_name, bucket, object_name)
+
+
+def generate_parquet_file(fname):
+    def _generate_value(index):
+        if index % 2 == 0:
+            return random.randint(1, 100)
+
+        alphanum = list(string.ascii_uppercase + string.digits)
+        random.shuffle(alphanum)
+        return ''.join(alphanum[:random.randint(1, 10)])
+
+
+    data = { f"col{i}": [_generate_value(i) for _ in range(100)] for i in range(10)}
+
+    df = pd.DataFrame(data=data)
+    df.to_parquet(f'{fname}.parquet.gzip', compression='gzip')
+
+def generate_parquet_test_files():
+    os.makedirs("/tmp/s3-parquet", exist_ok=True)
+
+    for ix_file in range(50):
+        generate_parquet_file(f'/tmp/s3-parquet/{ix_file}')
+        upload_file(f'/tmp/s3-parquet/{ix_file}.parquet.gzip', 's3-blob-reader')
+
+generate_parquet_test_files()

--- a/src/main/scala/services/blobsource/BlobSourceHookManager.scala
+++ b/src/main/scala/services/blobsource/BlobSourceHookManager.scala
@@ -1,0 +1,6 @@
+package com.sneaksanddata.arcane.framework
+package services.blobsource
+
+class BlobSourceHookManager {
+
+}

--- a/src/main/scala/services/blobsource/BlobSourceHookManager.scala
+++ b/src/main/scala/services/blobsource/BlobSourceHookManager.scala
@@ -1,6 +1,4 @@
 package com.sneaksanddata.arcane.framework
 package services.blobsource
 
-class BlobSourceHookManager {
-
-}
+class BlobSourceHookManager {}

--- a/src/main/scala/services/blobsource/base/BlobSourceDataProvider.scala
+++ b/src/main/scala/services/blobsource/base/BlobSourceDataProvider.scala
@@ -1,0 +1,6 @@
+package com.sneaksanddata.arcane.framework
+package services.blobsource.base
+
+class BlobSourceDataProvider {
+
+}

--- a/src/main/scala/services/blobsource/base/BlobSourceDataProvider.scala
+++ b/src/main/scala/services/blobsource/base/BlobSourceDataProvider.scala
@@ -1,6 +1,4 @@
 package com.sneaksanddata.arcane.framework
 package services.blobsource.base
 
-class BlobSourceDataProvider {
-
-}
+class BlobSourceDataProvider {}

--- a/src/main/scala/services/blobsource/base/BlobSourceReader.scala
+++ b/src/main/scala/services/blobsource/base/BlobSourceReader.scala
@@ -1,0 +1,20 @@
+//package com.sneaksanddata.arcane.framework
+//package services.blobsource.base
+//
+//import models.schemas.ArcaneSchema
+//
+//import com.sneaksanddata.arcane.framework.models.schemas.given_CanAdd_ArcaneSchema
+//import com.sneaksanddata.arcane.framework.services.base.SchemaProvider
+//import com.sneaksanddata.arcane.framework.services.storage.base.BlobStorageReader
+//import com.sneaksanddata.arcane.framework.services.storage.models.base.BlobPath
+//import zio.Task
+//
+//final class BlobSourceReader[PathType <: BlobPath](reader: BlobStorageReader[PathType]) extends SchemaProvider[ArcaneSchema]:
+//  override def getSchema: Task[SchemaType] = reader.readBlobContent()
+//
+//  /** Gets an empty schema.
+//   *
+//   * @return
+//   * An empty schema.
+//   */
+//  override def empty: SchemaType = ???

--- a/src/main/scala/services/storage/base/BlobStorageReader.scala
+++ b/src/main/scala/services/storage/base/BlobStorageReader.scala
@@ -23,14 +23,14 @@ trait BlobStorageReader[PathType <: BlobPath]:
     * @return
     *   A task containing the Reader instance. The reader returned by the function will be closed by the caller.
     */
-  def streamBlobContent(blobPath: AdlsStoragePath): Task[BufferedReader]
+  def streamBlobContent(blobPath: BlobPath): Task[BufferedReader]
 
   /** Reads blob content as a string
     * @param blobPath
     *   Path to blob
     * @return
     */
-  def readBlobContent(blobPath: AdlsStoragePath): Task[String]
+  def readBlobContent(blobPath: BlobPath): Task[String]
 
   /** Streams the prefixes of the blobs at the given root prefix.
     * @param rootPrefix

--- a/src/main/scala/services/storage/base/BlobStorageReader.scala
+++ b/src/main/scala/services/storage/base/BlobStorageReader.scala
@@ -23,14 +23,14 @@ trait BlobStorageReader[PathType <: BlobPath]:
     * @return
     *   A task containing the Reader instance. The reader returned by the function will be closed by the caller.
     */
-  def streamBlobContent(blobPath: BlobPath): Task[BufferedReader]
+  def streamBlobContent(blobPath: PathType): Task[BufferedReader]
 
   /** Reads blob content as a string
     * @param blobPath
     *   Path to blob
     * @return
     */
-  def readBlobContent(blobPath: BlobPath): Task[String]
+  def readBlobContent(blobPath: PathType): Task[String]
 
   /** Streams the prefixes of the blobs at the given root prefix.
     * @param rootPrefix

--- a/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
+++ b/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
@@ -4,12 +4,16 @@ package services.storage.models.s3
 import software.amazon.awssdk.regions.Region
 
 import java.net.URI
+import java.time.Duration
 
 case class S3ClientSettings(
   usePathStyle: Boolean,
   region: Option[Region],
   endpoint: Option[URI],
-  maxResultsPerPage: Int
+  maxResultsPerPage: Int,
+    retryMaxAttempts: Int,
+    retryBaseDelay: Duration,
+retryMaxDelay: Duration
 )
 
 object S3ClientSettings:
@@ -17,10 +21,16 @@ object S3ClientSettings:
       region: Option[String] = None,
       endpoint: Option[String] = None,
       pathStyleAccess: Boolean = false,
-        maxResultsPerPage: Int = 1000
+        maxResultsPerPage: Int = 1000,
+      retryMaxAttempts: Int = 5,
+        retryBaseDelay: Duration = Duration.ofMillis(100),
+      retryMaxDelay: Duration = Duration.ofSeconds(1)
   ): S3ClientSettings = new S3ClientSettings(
     region = region.map(Region.of),
     endpoint = endpoint.map(URI.create),
     usePathStyle = pathStyleAccess,
-    maxResultsPerPage = maxResultsPerPage
+    maxResultsPerPage = maxResultsPerPage,
+    retryMaxAttempts = retryMaxAttempts,
+    retryBaseDelay = retryBaseDelay, 
+    retryMaxDelay = retryMaxDelay
   )

--- a/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
+++ b/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
@@ -1,0 +1,26 @@
+package com.sneaksanddata.arcane.framework
+package services.storage.models.s3
+
+import software.amazon.awssdk.regions.Region
+
+import java.net.URI
+
+case class S3ClientSettings(
+  usePathStyle: Boolean,
+  region: Option[Region],
+  endpoint: Option[URI],
+  maxResultsPerPage: Int
+)
+
+object S3ClientSettings:
+  def apply(
+      region: Option[String] = None,
+      endpoint: Option[String] = None,
+      pathStyleAccess: Boolean = false,
+        maxResultsPerPage: Int = 1000
+  ): S3ClientSettings = new S3ClientSettings(
+    region = region.map(Region.of),
+    endpoint = endpoint.map(URI.create),
+    usePathStyle = pathStyleAccess,
+    maxResultsPerPage = maxResultsPerPage
+  )

--- a/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
+++ b/src/main/scala/services/storage/models/s3/S3ClientSettings.scala
@@ -7,13 +7,13 @@ import java.net.URI
 import java.time.Duration
 
 case class S3ClientSettings(
-  usePathStyle: Boolean,
-  region: Option[Region],
-  endpoint: Option[URI],
-  maxResultsPerPage: Int,
+    usePathStyle: Boolean,
+    region: Option[Region],
+    endpoint: Option[URI],
+    maxResultsPerPage: Int,
     retryMaxAttempts: Int,
     retryBaseDelay: Duration,
-retryMaxDelay: Duration
+    retryMaxDelay: Duration
 )
 
 object S3ClientSettings:
@@ -21,9 +21,9 @@ object S3ClientSettings:
       region: Option[String] = None,
       endpoint: Option[String] = None,
       pathStyleAccess: Boolean = false,
-        maxResultsPerPage: Int = 1000,
+      maxResultsPerPage: Int = 1000,
       retryMaxAttempts: Int = 5,
-        retryBaseDelay: Duration = Duration.ofMillis(100),
+      retryBaseDelay: Duration = Duration.ofMillis(100),
       retryMaxDelay: Duration = Duration.ofSeconds(1)
   ): S3ClientSettings = new S3ClientSettings(
     region = region.map(Region.of),
@@ -31,6 +31,6 @@ object S3ClientSettings:
     usePathStyle = pathStyleAccess,
     maxResultsPerPage = maxResultsPerPage,
     retryMaxAttempts = retryMaxAttempts,
-    retryBaseDelay = retryBaseDelay, 
+    retryBaseDelay = retryBaseDelay,
     retryMaxDelay = retryMaxDelay
   )

--- a/src/main/scala/services/storage/models/s3/S3ModelConversions.scala
+++ b/src/main/scala/services/storage/models/s3/S3ModelConversions.scala
@@ -1,0 +1,20 @@
+package com.sneaksanddata.arcane.framework
+package services.storage.models.s3
+
+import services.storage.models.base.StoredBlob
+
+import software.amazon.awssdk.services.s3.model.S3Object
+
+object S3ModelConversions:
+  given Conversion[S3Object, StoredBlob] with
+    override def apply(s3Obj: S3Object): StoredBlob =
+      StoredBlob(
+        metadata = Map(),
+        contentHash = None,
+        contentEncoding = None,
+        contentType = None,
+        contentLength = Some(s3Obj.size()),
+        name = s3Obj.key(),
+        lastModified = Some(s3Obj.lastModified().getEpochSecond),
+        createdOn = Some(s3Obj.lastModified().getEpochSecond)
+      )

--- a/src/main/scala/services/storage/models/s3/S3StoragePath.scala
+++ b/src/main/scala/services/storage/models/s3/S3StoragePath.scala
@@ -1,5 +1,5 @@
 package com.sneaksanddata.arcane.framework
-package services.storage.models.amazon
+package services.storage.models.s3
 
 import services.storage.models.base.BlobPath
 
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
   * @param objectKey
   *   The key of the object in the bucket.
   */
-final case class AmazonS3StoragePath(bucket: String, objectKey: String) extends BlobPath:
+final case class S3StoragePath(bucket: String, objectKey: String) extends BlobPath:
 
   /** Converts the path to a HDFS-style path.
     *
@@ -31,23 +31,23 @@ final case class AmazonS3StoragePath(bucket: String, objectKey: String) extends 
     *   The new path.
     */
   @targetName("plus")
-  def +(keyName: String): AmazonS3StoragePath =
+  def +(keyName: String): S3StoragePath =
     copy(objectKey = if (objectKey.isEmpty) keyName else s"$objectKey/$keyName")
 
-/** Companion object for [[AmazonS3StoragePath]].
+/** Companion object for [[S3StoragePath]].
   */
-object AmazonS3StoragePath {
+object S3StoragePath {
   private val matchRegex: String = "s3a://([^/]+)/?(.*)"
 
-  /** Creates an [[AmazonS3StoragePath]] from the given HDFS path.
+  /** Creates an [[S3StoragePath]] from the given HDFS path.
     *
     * @param hdfsPath
     *   The HDFS path.
     * @return
-    *   The [[AmazonS3StoragePath]].
+    * The [[S3StoragePath]].
     */
-  def apply(hdfsPath: String): Try[AmazonS3StoragePath] = matchRegex.r.findFirstMatchIn(hdfsPath) match {
-    case Some(matched) => Success(new AmazonS3StoragePath(matched.group(1), matched.group(2).stripSuffix("/")))
+  def apply(hdfsPath: String): Try[S3StoragePath] = matchRegex.r.findFirstMatchIn(hdfsPath) match {
+    case Some(matched) => Success(new S3StoragePath(matched.group(1), matched.group(2).stripSuffix("/")))
     case None =>
       Failure(
         IllegalArgumentException(s"An AmazonS3StoragePath must be in the format s3a://bucket/path, but was: $hdfsPath")

--- a/src/main/scala/services/storage/models/s3/S3StoragePath.scala
+++ b/src/main/scala/services/storage/models/s3/S3StoragePath.scala
@@ -44,7 +44,7 @@ object S3StoragePath {
     * @param hdfsPath
     *   The HDFS path.
     * @return
-    * The [[S3StoragePath]].
+    *   The [[S3StoragePath]].
     */
   def apply(hdfsPath: String): Try[S3StoragePath] = matchRegex.r.findFirstMatchIn(hdfsPath) match {
     case Some(matched) => Success(new S3StoragePath(matched.group(1), matched.group(2).stripSuffix("/")))

--- a/src/main/scala/services/storage/services/azure/AzureBlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/azure/AzureBlobStorageReader.scala
@@ -5,7 +5,7 @@ import logging.ZIOLogAnnotations.zlog
 import services.storage.base.BlobStorageReader
 import services.storage.models.azure.AzureModelConversions.given
 import services.storage.models.azure.{AdlsStoragePath, AzureBlobStorageReaderSettings}
-import services.storage.models.base.StoredBlob
+import services.storage.models.base.{BlobPath, StoredBlob}
 
 import com.azure.core.credential.TokenCredential
 import com.azure.identity.DefaultAzureCredentialBuilder

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -1,0 +1,37 @@
+package com.sneaksanddata.arcane.framework
+package services.storage.services.s3
+
+import services.storage.models.s3.{S3ClientSettings, S3StoragePath}
+
+import com.sneaksanddata.arcane.framework.services.storage.base.BlobStorageReader
+import com.sneaksanddata.arcane.framework.services.storage.models.base.{BlobPath, StoredBlob}
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.services.s3.S3Client
+import zio.Task
+import zio.stream.ZStream
+
+import java.io.BufferedReader
+
+final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends BlobStorageReader[S3StoragePath]:
+  private val serviceClientSettings = settings.getOrElse(S3ClientSettings())
+  private val defaultCredential = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
+  private val s3Client = {
+    var builder = S3Client.builder().credentialsProvider(defaultCredential).forcePathStyle(serviceClientSettings.usePathStyle).crossRegionAccessEnabled(true).dualstackEnabled(true)
+    
+    if (serviceClientSettings.region.isDefined) 
+      builder = builder.region(serviceClientSettings.region.get)
+      
+    if (serviceClientSettings.endpoint.isDefined)
+      builder = builder.endpointOverride(serviceClientSettings.endpoint.get)
+    
+    builder.build()
+  }
+
+
+  override def blobExists(blobPath: S3StoragePath): Task[Boolean] = ???
+
+  override def readBlobContent(blobPath: BlobPath): Task[String] = ???
+
+  override def streamBlobContent(blobPath: BlobPath): Task[BufferedReader] = ???
+
+  override def streamPrefixes(rootPrefix: S3StoragePath): ZStream[Any, Throwable, StoredBlob] = ???

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -15,10 +15,16 @@ import java.io.BufferedReader
 
 final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends BlobStorageReader[S3StoragePath]:
   private val serviceClientSettings = settings.getOrElse(S3ClientSettings())
-  private val defaultCredential = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
-  private val retryStrategy = AwsRetryStrategy.standardRetryStrategy().toBuilder.maxAttempts(serviceClientSettings.retryMaxAttempts)
+  private val defaultCredential     = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
+  private val retryStrategy =
+    AwsRetryStrategy.standardRetryStrategy().toBuilder.maxAttempts(serviceClientSettings.retryMaxAttempts)
   private val s3Client = {
-    var builder = S3Client.builder().credentialsProvider(defaultCredential).forcePathStyle(serviceClientSettings.usePathStyle).crossRegionAccessEnabled(true).dualstackEnabled(true)
+    var builder = S3Client
+      .builder()
+      .credentialsProvider(defaultCredential)
+      .forcePathStyle(serviceClientSettings.usePathStyle)
+      .crossRegionAccessEnabled(true)
+      .dualstackEnabled(true)
 
     if (serviceClientSettings.region.isDefined)
       builder = builder.region(serviceClientSettings.region.get)
@@ -28,7 +34,6 @@ final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends Blob
 
     builder.build()
   }
-
 
   override def blobExists(blobPath: S3StoragePath): Task[Boolean] = ???
 

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -7,8 +7,10 @@ import com.sneaksanddata.arcane.framework.services.storage.base.BlobStorageReade
 import com.sneaksanddata.arcane.framework.services.storage.models.base.{BlobPath, StoredBlob}
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy
+import software.amazon.awssdk.retries.api.BackoffStrategy
 import software.amazon.awssdk.services.s3.S3Client
-import zio.Task
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import zio.{Task, ZIO}
 import zio.stream.ZStream
 
 import java.io.BufferedReader
@@ -17,14 +19,23 @@ final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends Blob
   private val serviceClientSettings = settings.getOrElse(S3ClientSettings())
   private val defaultCredential     = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
   private val retryStrategy =
-    AwsRetryStrategy.standardRetryStrategy().toBuilder.maxAttempts(serviceClientSettings.retryMaxAttempts)
-  private val s3Client = {
+    AwsRetryStrategy
+      .standardRetryStrategy()
+      .toBuilder
+      .maxAttempts(serviceClientSettings.retryMaxAttempts)
+      .backoffStrategy(
+        BackoffStrategy.exponentialDelay(serviceClientSettings.retryBaseDelay, serviceClientSettings.retryMaxDelay)
+      )
+      .circuitBreakerEnabled(true)
+      .build()
+  private val s3Client: S3Client = {
     var builder = S3Client
       .builder()
       .credentialsProvider(defaultCredential)
       .forcePathStyle(serviceClientSettings.usePathStyle)
       .crossRegionAccessEnabled(true)
       .dualstackEnabled(true)
+      .overrideConfiguration(o => o.retryStrategy(retryStrategy))
 
     if (serviceClientSettings.region.isDefined)
       builder = builder.region(serviceClientSettings.region.get)
@@ -35,10 +46,15 @@ final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends Blob
     builder.build()
   }
 
-  override def blobExists(blobPath: S3StoragePath): Task[Boolean] = ???
+  override def blobExists(blobPath: S3StoragePath): Task[Boolean] = ZIO
+    .attemptBlocking(
+      s3Client.headObject(HeadObjectRequest.builder().bucket(blobPath.bucket).key(blobPath.objectKey).build())
+    )
+    .flatMap(result => ZIO.logDebug(s"Blob ${blobPath.toHdfsPath} exists: ${result.eTag()}") *> ZIO.succeed(true))
+    .onError(_ => ZIO.logDebug(s"Blob ${blobPath.toHdfsPath} does not exist") *> ZIO.succeed(false))
 
-  override def readBlobContent(blobPath: BlobPath): Task[String] = ???
+  override def readBlobContent(blobPath: S3StoragePath): Task[String] = ???
 
-  override def streamBlobContent(blobPath: BlobPath): Task[BufferedReader] = ???
+  override def streamBlobContent(blobPath: S3StoragePath): Task[BufferedReader] = ???
 
   override def streamPrefixes(rootPrefix: S3StoragePath): ZStream[Any, Throwable, StoredBlob] = ???

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -93,27 +93,23 @@ final class S3BlobStorageReader(
       .map(sr => new BufferedReader(sr))
   yield streamReader
 
+  private def preBuildListObjectsV2Request(bucket: String, key: String): ListObjectsV2Request.Builder =
+    ListObjectsV2Request
+      .builder()
+      .bucket(bucket)
+      .prefix(key)
+      .maxKeys(serviceClientSettings.maxResultsPerPage)
+
   override def streamPrefixes(rootPrefix: S3StoragePath): ZStream[Any, Throwable, StoredBlob] = ZStream
     .paginate(
-      s3Client.listObjectsV2(
-        ListObjectsV2Request
-          .builder()
-          .bucket(rootPrefix.bucket)
-          .prefix(rootPrefix.objectKey)
-          .maxKeys(serviceClientSettings.maxResultsPerPage)
-          .build()
-      )
+      s3Client.listObjectsV2(preBuildListObjectsV2Request(rootPrefix.bucket, rootPrefix.objectKey).build())
     ) { response =>
       if (response.isTruncated()) {
         (
           response.contents().asScala.toList,
           Some(
             s3Client.listObjectsV2(
-              ListObjectsV2Request
-                .builder()
-                .bucket(rootPrefix.bucket)
-                .prefix(rootPrefix.objectKey)
-                .maxKeys(serviceClientSettings.maxResultsPerPage)
+              preBuildListObjectsV2Request(rootPrefix.bucket, rootPrefix.objectKey)
                 .continuationToken(response.nextContinuationToken())
                 .build()
             )

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -6,6 +6,7 @@ import services.storage.models.s3.{S3ClientSettings, S3StoragePath}
 import com.sneaksanddata.arcane.framework.services.storage.base.BlobStorageReader
 import com.sneaksanddata.arcane.framework.services.storage.models.base.{BlobPath, StoredBlob}
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy
 import software.amazon.awssdk.services.s3.S3Client
 import zio.Task
 import zio.stream.ZStream
@@ -15,15 +16,16 @@ import java.io.BufferedReader
 final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends BlobStorageReader[S3StoragePath]:
   private val serviceClientSettings = settings.getOrElse(S3ClientSettings())
   private val defaultCredential = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
+  private val retryStrategy = AwsRetryStrategy.standardRetryStrategy().toBuilder.maxAttempts(serviceClientSettings.retryMaxAttempts)
   private val s3Client = {
     var builder = S3Client.builder().credentialsProvider(defaultCredential).forcePathStyle(serviceClientSettings.usePathStyle).crossRegionAccessEnabled(true).dualstackEnabled(true)
-    
-    if (serviceClientSettings.region.isDefined) 
+
+    if (serviceClientSettings.region.isDefined)
       builder = builder.region(serviceClientSettings.region.get)
-      
+
     if (serviceClientSettings.endpoint.isDefined)
       builder = builder.endpointOverride(serviceClientSettings.endpoint.get)
-    
+
     builder.build()
   }
 

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -7,11 +7,21 @@ import services.storage.models.base.StoredBlob
 import services.storage.models.s3.S3ModelConversions.given
 import services.storage.models.s3.{S3ClientSettings, S3StoragePath}
 
-import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, AwsCredentials, DefaultCredentialsProvider, StaticCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  AwsCredentials,
+  DefaultCredentialsProvider,
+  StaticCredentialsProvider
+}
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy
 import software.amazon.awssdk.retries.api.BackoffStrategy
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, ListObjectsV2Request, NoSuchKeyException}
+import software.amazon.awssdk.services.s3.model.{
+  GetObjectRequest,
+  HeadObjectRequest,
+  ListObjectsV2Request,
+  NoSuchKeyException
+}
 import zio.stream.ZStream
 import zio.{Task, ZIO}
 
@@ -61,9 +71,8 @@ final class S3BlobStorageReader(
       s3Client.headObject(HeadObjectRequest.builder().bucket(blobPath.bucket).key(blobPath.objectKey).build())
     )
     .flatMap(result => ZIO.logDebug(s"Blob ${blobPath.toHdfsPath} exists: ${result.eTag()}") *> ZIO.succeed(true))
-    .catchSome {
-      case _: NoSuchKeyException =>
-        ZIO.logDebug(s"Blob ${blobPath.toHdfsPath} does not exist") *> ZIO.succeed(false)
+    .catchSome { case _: NoSuchKeyException =>
+      ZIO.logDebug(s"Blob ${blobPath.toHdfsPath} does not exist") *> ZIO.succeed(false)
     }
 
   override def readBlobContent(blobPath: S3StoragePath): Task[String] = for
@@ -105,7 +114,7 @@ final class S3BlobStorageReader(
                 .bucket(rootPrefix.bucket)
                 .prefix(rootPrefix.objectKey)
                 .maxKeys(serviceClientSettings.maxResultsPerPage)
-                .continuationToken(response.continuationToken())
+                .continuationToken(response.nextContinuationToken())
                 .build()
             )
           )

--- a/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
+++ b/src/main/scala/services/storage/services/s3/S3BlobStorageReader.scala
@@ -1,23 +1,23 @@
 package com.sneaksanddata.arcane.framework
 package services.storage.services.s3
 
+import logging.ZIOLogAnnotations.zlog
+import services.storage.base.BlobStorageReader
+import services.storage.models.base.StoredBlob
+import services.storage.models.s3.S3ModelConversions.given
 import services.storage.models.s3.{S3ClientSettings, S3StoragePath}
 
-import com.sneaksanddata.arcane.framework.logging.ZIOLogAnnotations.zlog
-import com.sneaksanddata.arcane.framework.services.storage.base.BlobStorageReader
-import com.sneaksanddata.arcane.framework.services.storage.models.base.{BlobPath, StoredBlob}
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy
 import software.amazon.awssdk.retries.api.BackoffStrategy
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, ListObjectsV2Request}
-import services.storage.models.s3.S3ModelConversions.given
-import zio.{Task, ZIO}
 import zio.stream.ZStream
-import scala.jdk.CollectionConverters.*
-import scala.language.implicitConversions
+import zio.{Task, ZIO}
 
 import java.io.{BufferedReader, InputStreamReader}
+import scala.jdk.CollectionConverters.*
+import scala.language.implicitConversions
 
 final class S3BlobStorageReader(settings: Option[S3ClientSettings]) extends BlobStorageReader[S3StoragePath]:
   private val serviceClientSettings = settings.getOrElse(S3ClientSettings())

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -22,11 +22,12 @@ object S3BlobStorageReaderTests extends ZIOSpecDefault {
         result <- storageReader.blobExists(path)
       yield assertTrue(!result)
     },
+    // maxKeys 5 is applied during the test, ensuring we test pagination as well
     test("streamPrefixes returns a stream of correct length") {
       for
         path     <- ZIO.succeed(S3StoragePath(s"s3a://$bucket").get)
         prefixes <- storageReader.streamPrefixes(path).runCount
       yield assertTrue(prefixes == 50)
-    }
+    },
   )
 }

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -1,11 +1,20 @@
 package com.sneaksanddata.arcane.framework
 package tests.s3
 
-import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault}
+import services.storage.models.s3.S3StoragePath
+import tests.shared.S3StorageInfo.storageReader
+
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, ZIO}
 
 object S3BlobStorageReaderTests extends ZIOSpecDefault {
+  val bucket = "s3-blob-reader"
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("S3BlobStorageReader")(
-    
+    test(s"correctly check if a blob exists in a container") {
+      for
+        path   <- ZIO.succeed(S3StoragePath(s"s3a://$bucket/0.parquet.zip").get)
+        result <- storageReader.blobExists(path)
+      yield assertTrue(result)
+    }
   )
 }

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -10,17 +10,23 @@ import zio.{Scope, ZIO}
 object S3BlobStorageReaderTests extends ZIOSpecDefault {
   val bucket = "s3-blob-reader"
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("S3BlobStorageReader")(
-    test(s"blobExists returns true if a blob exists in a bucket") {
+    test("blobExists returns true if a blob exists in a bucket") {
       for
         path   <- ZIO.succeed(S3StoragePath(s"s3a://$bucket/0.parquet.gzip").get)
         result <- storageReader.blobExists(path)
       yield assertTrue(result)
     },
-    test(s"blobExists returns false and doesn't error if a blob does not exist in a bucket") {
+    test("blobExists returns false and doesn't error if a blob does not exist in a bucket") {
       for
         path   <- ZIO.succeed(S3StoragePath(s"s3a://$bucket/0.parquet.zip").get)
         result <- storageReader.blobExists(path)
       yield assertTrue(!result)
-    }    
+    },
+    test("streamPrefixes returns a stream of correct length") {
+      for
+        path     <- ZIO.succeed(S3StoragePath(s"s3a://$bucket").get)
+        prefixes <- storageReader.streamPrefixes(path).runCount
+      yield assertTrue(prefixes == 50)
+    }
   )
 }

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -28,6 +28,6 @@ object S3BlobStorageReaderTests extends ZIOSpecDefault {
         path     <- ZIO.succeed(S3StoragePath(s"s3a://$bucket").get)
         prefixes <- storageReader.streamPrefixes(path).runCount
       yield assertTrue(prefixes == 50)
-    },
+    }
   )
 }

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -10,11 +10,17 @@ import zio.{Scope, ZIO}
 object S3BlobStorageReaderTests extends ZIOSpecDefault {
   val bucket = "s3-blob-reader"
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("S3BlobStorageReader")(
-    test(s"correctly check if a blob exists in a container") {
+    test(s"blobExists returns true if a blob exists in a bucket") {
+      for
+        path   <- ZIO.succeed(S3StoragePath(s"s3a://$bucket/0.parquet.gzip").get)
+        result <- storageReader.blobExists(path)
+      yield assertTrue(result)
+    },
+    test(s"blobExists returns false and doesn't error if a blob does not exist in a bucket") {
       for
         path   <- ZIO.succeed(S3StoragePath(s"s3a://$bucket/0.parquet.zip").get)
         result <- storageReader.blobExists(path)
-      yield assertTrue(result)
-    }
+      yield assertTrue(!result)
+    }    
   )
 }

--- a/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
+++ b/src/test/scala/tests/s3/S3BlobStorageReaderTests.scala
@@ -1,0 +1,11 @@
+package com.sneaksanddata.arcane.framework
+package tests.s3
+
+import zio.Scope
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault}
+
+object S3BlobStorageReaderTests extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("S3BlobStorageReader")(
+    
+  )
+}

--- a/src/test/scala/tests/services/storage/models/amazon/AmazonS3StoragePathTests.scala
+++ b/src/test/scala/tests/services/storage/models/amazon/AmazonS3StoragePathTests.scala
@@ -1,7 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package tests.services.storage.models.amazon
 
-import services.storage.models.amazon.AmazonS3StoragePath
+import services.storage.models.s3.S3StoragePath
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
@@ -15,33 +15,33 @@ class AmazonS3StoragePathTests extends AnyFlatSpec with Matchers {
 
   "AmazonS3StoragePath" should "be able to parse correct path" in {
     val path   = "s3a://bucket/key"
-    val parsed = AmazonS3StoragePath(path)
+    val parsed = S3StoragePath(path)
 
-    parsed should be(Success(AmazonS3StoragePath("bucket", "key")))
+    parsed should be(Success(S3StoragePath("bucket", "key")))
   }
 
   it should "have stable serialization and deserialization" in {
     val path       = "s3a://bucket/key"
-    val parsed     = AmazonS3StoragePath(path)
-    val serialized = AmazonS3StoragePath(parsed.get.toHdfsPath)
+    val parsed     = S3StoragePath(path)
+    val serialized = S3StoragePath(parsed.get.toHdfsPath)
 
-    parsed should be(Success(AmazonS3StoragePath(serialized.get.bucket, serialized.get.objectKey)))
+    parsed should be(Success(S3StoragePath(serialized.get.bucket, serialized.get.objectKey)))
   }
 
   it should "serialize and deserialize s3 paths in the same way" in {
     val path       = "s3a://bucket/key"
-    val parsed     = AmazonS3StoragePath(path)
-    val serialized = AmazonS3StoragePath(parsed.get.toHdfsPath)
+    val parsed     = S3StoragePath(path)
+    val serialized = S3StoragePath(parsed.get.toHdfsPath)
 
     parsed.get.toHdfsPath should be(serialized.get.toHdfsPath)
   }
 
   it should "be able to jon paths" in {
     val path         = "s3a://bucket/key"
-    val parsed       = AmazonS3StoragePath(path)
+    val parsed       = S3StoragePath(path)
     val parsedJoined = parsed.get + "key2"
 
-    parsedJoined should be(AmazonS3StoragePath("bucket", "key/key2"))
+    parsedJoined should be(S3StoragePath("bucket", "key/key2"))
   }
 
   private val joinPathCases = Table(
@@ -57,7 +57,7 @@ class AmazonS3StoragePathTests extends AnyFlatSpec with Matchers {
 
   forAll(joinPathCases) { (orig: String, rest: String, expectedResult: String) =>
     it should f"be able to remove extra slashes with values ($orig, $rest, $expectedResult)" in {
-      val parsed = AmazonS3StoragePath(orig)
+      val parsed = S3StoragePath(orig)
       val result = parsed.get + rest
 
       result.toHdfsPath should be(expectedResult)

--- a/src/test/scala/tests/shared/S3StorageInfo.scala
+++ b/src/test/scala/tests/shared/S3StorageInfo.scala
@@ -1,0 +1,24 @@
+package com.sneaksanddata.arcane.framework
+package tests.shared
+
+import services.storage.models.s3.S3ClientSettings
+import services.storage.services.s3.S3BlobStorageReader
+
+object S3StorageInfo:
+  val bucket          = "s3-blob-reader"
+  val accessKeyId     = "minioadmin"
+  val secretAccessKey = "minioadmin"
+  val endpoint        = "http://localhost:9000"
+
+  val storageReader = S3BlobStorageReader(
+    Some(secretAccessKey),
+    Some(accessKeyId),
+    Some(
+      S3ClientSettings(
+        region = Some("us-east-1"),
+        endpoint = Some(endpoint),
+        pathStyleAccess = true,
+        maxResultsPerPage = 5
+      )
+    )
+  )

--- a/src/test/scala/tests/shared/S3StorageInfo.scala
+++ b/src/test/scala/tests/shared/S3StorageInfo.scala
@@ -4,6 +4,8 @@ package tests.shared
 import services.storage.models.s3.S3ClientSettings
 import services.storage.services.s3.S3BlobStorageReader
 
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+
 object S3StorageInfo:
   val bucket          = "s3-blob-reader"
   val accessKeyId     = "minioadmin"
@@ -11,8 +13,7 @@ object S3StorageInfo:
   val endpoint        = "http://localhost:9000"
 
   val storageReader = S3BlobStorageReader(
-    Some(secretAccessKey),
-    Some(accessKeyId),
+    StaticCredentialsProvider.create(AwsBasicCredentials.create(secretAccessKey, accessKeyId)),
     Some(
       S3ClientSettings(
         region = Some("us-east-1"),


### PR DESCRIPTION
Part of #175 

## Scope

- Add implementation of `BlobStorageReader` for S3
- Add tests for stream prefixes and blob exists

## TODO in the follow-ups
- Add stream blob content overload that returns a stream of bytes rather that a stream of text
- Add writer implementation to support object deletion
- Fully test all methods available in S3 reader