### PR TITLE
Attach configurable exp backoff retries to JDBC MergeClient

### DIFF
--- a/src/main/scala/models/settings/JdbcMergeServiceClientSettings.scala
+++ b/src/main/scala/models/settings/JdbcMergeServiceClientSettings.scala
@@ -1,8 +1,25 @@
 package com.sneaksanddata.arcane.framework
 package models.settings
 
+import zio.Duration
+
 import java.sql.DriverManager
 import scala.util.Try
+
+/** Retry modes available for the client
+  */
+enum JdbcQueryRetryMode:
+  /** Always retry
+    */
+  case Always
+
+  /** Only retry in backfill mode
+    */
+  case BackfillOnly
+
+  /** Never retry
+    */
+  case Never
 
 trait JdbcMergeServiceClientSettings:
   /** The connection URL.
@@ -12,6 +29,26 @@ trait JdbcMergeServiceClientSettings:
   /** Optional extra connection parameters for the merge client (tags, session properties etc.)
     */
   val extraConnectionParameters: Map[String, String]
+
+  /** Enable query retries for JDBC merge
+    */
+  val queryRetryMode: JdbcQueryRetryMode
+
+  /** Exp retry base duration
+    */
+  val queryRetryBaseDuration: Duration
+
+  /** Exp retry scale factor
+    */
+  val queryRetryScaleFactor: Double
+
+  /** Exp retry max attempts
+    */
+  val queryRetryMaxAttempts: Int
+
+  /** Exception messages to retry
+    */
+  val queryRetryOnMessageContents: List[String]
 
   /** Checks if the connection URL is valid.
     *

--- a/src/main/scala/services/merging/JdbcMergeServiceClient.scala
+++ b/src/main/scala/services/merging/JdbcMergeServiceClient.scala
@@ -4,6 +4,7 @@ package services.merging
 import logging.ZIOLogAnnotations.*
 import models.app.StreamContext
 import models.schemas.ArcaneSchema
+import models.settings.JdbcQueryRetryMode.{Always, BackfillOnly, Never}
 import models.settings.backfill.BackfillSettings
 import models.settings.sink.SinkSettings
 import models.settings.{JdbcMergeServiceClientSettings, TablePropertiesSettings}
@@ -16,9 +17,10 @@ import services.metrics.DeclaredMetrics.*
 import org.apache.iceberg.types.Type
 import org.apache.iceberg.types.Type.TypeID
 import org.apache.iceberg.types.Types.{DecimalType, ListType, StructType, TimestampType}
-import zio.{Task, ZIO, ZLayer}
+import zio.{Schedule, Task, ZIO, ZLayer}
 
-import java.sql.{Connection, DriverManager}
+import java.io.IOException
+import java.sql.*
 import scala.jdk.CollectionConverters.*
 
 trait JdbcTableManager extends TableManager:
@@ -57,6 +59,24 @@ class JdbcMergeServiceClient(
   require(options.isValid, "Invalid JDBC url provided for the consumer")
 
   private lazy val sqlConnection: Connection = DriverManager.getConnection(options.getConnectionString)
+
+  private val retryPolicy =
+    val backoffPolicy =
+      Schedule.exponential(options.queryRetryBaseDuration, options.queryRetryScaleFactor).jittered && Schedule.recurs(
+        options.queryRetryMaxAttempts
+      ) && Schedule.recurWhile[Throwable] {
+        case _: IOException                     => true
+        case _: SQLFeatureNotSupportedException => false
+        case _: SQLTimeoutException             => false
+        case e: SQLException => options.queryRetryOnMessageContents.exists(prefix => e.getMessage.contains(prefix))
+        case _               => false
+      }
+
+    options.queryRetryMode match
+      case Never                                       => Schedule.stop
+      case Always                                      => backoffPolicy
+      case BackfillOnly if streamContext.IsBackfilling => backoffPolicy
+      case _                                           => Schedule.stop
 
   /** @inheritdoc
     */
@@ -119,6 +139,8 @@ class JdbcMergeServiceClient(
 
   private type ResultMapper[Result] = Boolean => Result
 
+  private def observeStatementResult(statement: PreparedStatement): Task[Unit] = ???
+
   private def executeBatchQuery[Result](
       query: String,
       batchName: String,
@@ -129,7 +151,8 @@ class JdbcMergeServiceClient(
       for
         statement         <- ZIO.fromAutoCloseable(ZIO.attempt(sqlConnection.prepareStatement(query)))
         _                 <- zlog(s"$operation batch $batchName")
-        applicationResult <- ZIO.attempt(statement.execute())
+        applicationResult <- ZIO.attempt(statement.execute()).retry(retryPolicy)
+        executionResult   <- ZIO.attempt(statement.getResultSet)
       yield resultMapper(applicationResult)
     }
 

--- a/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
+++ b/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
@@ -5,7 +5,8 @@ import models.app.StreamContext
 import models.batches.SynapseLinkMergeBatch
 import models.schemas.ArcaneType.{BooleanType, LongType, StringType}
 import models.schemas.{ArcaneSchema, Field, MergeKeyField}
-import models.settings.JdbcMergeServiceClientSettings
+import models.settings.JdbcQueryRetryMode.Never
+import models.settings.{JdbcMergeServiceClientSettings, JdbcQueryRetryMode}
 import services.base.SchemaProvider
 import services.filters.FieldsFilteringService
 import services.merging.*
@@ -16,7 +17,7 @@ import services.merging.maintenance.{
 }
 import services.metrics.{ArcaneDimensionsProvider, DeclaredMetrics}
 import tests.services.merging.JdbcMergeServiceClientTests.test
-import tests.shared.{TestBackfillTableSettings, TestTablePropertiesSettings, TestSinkSettings}
+import tests.shared.{TestBackfillTableSettings, TestSinkSettings, TestTablePropertiesSettings}
 
 import io.trino.jdbc.TrinoDriver
 import org.scalatestplus.easymock.EasyMockSugar
@@ -49,6 +50,12 @@ object JdbcMergeServiceClientTests extends ZIOSpecDefault:
     override val connectionUrl: String = connectionUri
 
     override val extraConnectionParameters: Map[String, String] = Map()
+
+    override val queryRetryMode: JdbcQueryRetryMode        = Never
+    override val queryRetryOnMessageContents: List[String] = List()
+    override val queryRetryBaseDuration: zio.Duration      = zio.Duration.Zero
+    override val queryRetryMaxAttempts: Int                = 1
+    override val queryRetryScaleFactor: Double             = 1
 
   private def getJdbcMergeServiceClient =
     new JdbcMergeServiceClient(


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/arcane-framework-scala/issues/279