### PR TITLE
[Iceberg API] Add waiter loop for fast append commit propagation

### DIFF
--- a/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
+++ b/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
@@ -104,14 +104,14 @@ class IcebergS3CatalogWriter(entityManager: StagingEntityManager, stagingSetting
       _ <- entityManager.createTable(CreateTableRequest(name, schema, false))
       _ <- zlog("Created a staging table %s, waiting for commit", logAnnotations, name)
       _ <- ZIO
-        .sleep(zio.Duration.fromSeconds(1))
+        .sleep(zio.Duration.fromMillis(100))
         .repeatUntilZIO(_ => entityManager.tableExists(name).orDie)
       _            <- zlog("Staging table %s created, appending data", logAnnotations, name)
       table        <- entityManager.getTableRef(name)
       updatedTable <- appendData(data, schema, false, table, logAnnotations)
       _            <- zlog("Waiting for fast append into %s to propagate in the catalog database", logAnnotations, name)
       _ <- ZIO
-        .sleep(zio.Duration.fromSeconds(1))
+        .sleep(zio.Duration.fromMillis(100))
         .repeatUntilZIO(_ => entityManager.getTableRef(name).map(_.snapshots().asScala.size == 2).orDie)
       _ <- zlog("Staging table %s ready for merge", logAnnotations, name)
     yield updatedTable

--- a/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
+++ b/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
@@ -112,7 +112,7 @@ class IcebergS3CatalogWriter(entityManager: StagingEntityManager, stagingSetting
       _            <- zlog("Waiting for fast append into %s to propagate in the catalog database", logAnnotations, name)
       _ <- ZIO
         .sleep(zio.Duration.fromMillis(100))
-        .repeatUntilZIO(_ => entityManager.getTableRef(name).map(_.snapshots().asScala.size == 2).orDie)
+        .repeatUntilZIO(_ => entityManager.getTableRef(name).map(_.snapshots().asScala.size == 1).orDie)
       _ <- zlog("Staging table %s ready for merge", logAnnotations, name)
     yield updatedTable
 

--- a/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
+++ b/src/main/scala/services/iceberg/IcebergS3CatalogWriter.scala
@@ -109,7 +109,11 @@ class IcebergS3CatalogWriter(entityManager: StagingEntityManager, stagingSetting
       _            <- zlog("Staging table %s created, appending data", logAnnotations, name)
       table        <- entityManager.getTableRef(name)
       updatedTable <- appendData(data, schema, false, table, logAnnotations)
-      _            <- zlog("Staging table %s ready for merge", logAnnotations, name)
+      _            <- zlog("Waiting for fast append into %s to propagate in the catalog database", logAnnotations, name)
+      _ <- ZIO
+        .sleep(zio.Duration.fromSeconds(1))
+        .repeatUntilZIO(_ => entityManager.getTableRef(name).map(_.snapshots().asScala.size == 2).orDie)
+      _ <- zlog("Staging table %s ready for merge", logAnnotations, name)
     yield updatedTable
 
   def append(


### PR DESCRIPTION
Fixes https://github.com/SneaksAndData/arcane-framework-scala/issues/377

In addition, reduce poll interval from 1000ms to 100ms