### PR TITLE
[JDBC] Construct connection string with default catalog and schema from staging settings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
     command: [ "/bin/sh", "-c", "pip install boto3 pandas pyarrow fastparquet && python /populate-s3-reader-bucket.py"  ]
   # https://github.com/databricks/docker-spark-iceberg/blob/main/docker-compose.yml
   lakekeeper:
-    image: quay.io/lakekeeper/catalog:v0.11.2
+    image: quay.io/lakekeeper/catalog:v0.11.4
     network_mode: host
     environment:
       #      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
@@ -120,7 +120,7 @@ services:
       - ./populate-cdm-container.py:/populate-cdm-container.py
     command: [ "/bin/sh", "-c", "pip install azure-storage-blob==12.24.1 requests && python /populate-cdm-container.py" ]
   lakekeeper_migrate:
-    image: quay.io/lakekeeper/catalog:v0.11.2
+    image: quay.io/lakekeeper/catalog:v0.11.4
     network_mode: host
     environment:
       #      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!

--- a/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
+++ b/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
@@ -34,12 +34,12 @@ object JdbcConnectionExtensions:
         .mkString("&")
       // check if URL has parameters
       Option(new URI(url).getQuery) match
-        case Some(_) =>
+        case None =>
           Seq(
             s"$url/?",
             paramString
           ).mkString("")
-        case None =>
+        case Some(_) =>
           Seq(
             url,
             paramString

--- a/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
+++ b/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
@@ -26,7 +26,7 @@ object JdbcConnectionExtensions:
       * @return
       */
     def withUrlParameters(extraParameters: Map[String, String]): String = if extraParameters.isEmpty then url
-    else {
+    else
       val paramString = extraParameters
         .map { case (key, value) =>
           s"$key=$value"
@@ -44,8 +44,6 @@ object JdbcConnectionExtensions:
             url,
             paramString
           ).mkString("&")
-
-    }
 
     /** Attaches extra parameters as connection string parameters with `;` separator
       */

--- a/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
+++ b/src/main/scala/models/settings/database/JdbcConnectionExtensions.scala
@@ -1,21 +1,51 @@
 package com.sneaksanddata.arcane.framework
 package models.settings.database
 
+import java.net.URI
+
 object JdbcConnectionExtensions:
   extension (url: JdbcConnectionUrl)
+    /** Attaches a default catalog as URL query path segment
+      * @return
+      */
+    def withDefaultCatalog(catalog: String): String =
+      // only allow this for base URI
+      val uri = new URI(url)
+      require(
+        uri.isAbsolute && Option(uri.getFragment).isEmpty,
+        "Cannot attach catalog to the provided JDBC URL. Please provide an absolute URL with an empty path."
+      )
+      s"$url/$catalog"
+
+    /** Attaches a default schema as URL query path segment
+      * @return
+      */
+    def withDefaultSchema(schema: String): String = s"$url/$schema"
+
     /** Attaches extra parameters as URL query parameters
       * @return
       */
     def withUrlParameters(extraParameters: Map[String, String]): String = if extraParameters.isEmpty then url
-    else
-      Seq(
-        url,
-        extraParameters
-          .map { case (key, value) =>
-            s"$key=$value"
-          }
-          .mkString("&")
-      ).mkString("&")
+    else {
+      val paramString = extraParameters
+        .map { case (key, value) =>
+          s"$key=$value"
+        }
+        .mkString("&")
+      // check if URL has parameters
+      Option(new URI(url).getQuery) match
+        case Some(_) =>
+          Seq(
+            s"$url/?",
+            paramString
+          ).mkString("")
+        case None =>
+          Seq(
+            url,
+            paramString
+          ).mkString("&")
+
+    }
 
     /** Attaches extra parameters as connection string parameters with `;` separator
       */

--- a/src/main/scala/models/settings/staging/JdbcCredentialType.scala
+++ b/src/main/scala/models/settings/staging/JdbcCredentialType.scala
@@ -1,0 +1,45 @@
+package com.sneaksanddata.arcane.framework
+package models.settings.staging
+
+import upickle.ReadWriter
+import upickle.implicits.key
+
+/** Credential type for the JDBC connection
+  */
+sealed trait JdbcCredentialType
+
+/** Standard username-password credential
+  */
+case class BasicCredential(
+    @key("user") userSetting: Option[String] = None,
+    @key("password") passwordSetting: Option[String] = None
+) derives ReadWriter:
+  private val user: String     = userSetting.getOrElse(sys.env("ARCANE_FRAMEWORK__JDBC_MERGE_SERVICE_USER"))
+  private val password: String = passwordSetting.getOrElse(sys.env("ARCANE_FRAMEWORK__JDBC_MERGE_SERVICE_PASSWORD"))
+
+  def asParameters: Map[String, String] = Map(
+    "user"     -> user,
+    "password" -> password
+  )
+
+/** ADT proxy for BasicCredential
+  */
+case class BasicCredentialImpl(credential: BasicCredential) extends JdbcCredentialType
+
+/** No auth credential
+  */
+case class AnonymousCredential() derives ReadWriter
+
+/** ADT proxy for AnonymousCredential
+  */
+case class AnonymousCredentialImpl(credential: AnonymousCredential) extends JdbcCredentialType
+
+/** Setting class proxy
+  */
+case class JdbcCredentialTypeSetting(
+    basic: Option[BasicCredential] = None,
+    anonymous: Option[AnonymousCredential] = None
+) derives ReadWriter:
+  def resolveCredentialType: JdbcCredentialType = basic
+    .map(BasicCredentialImpl(_))
+    .getOrElse(anonymous.map(AnonymousCredentialImpl(_)).getOrElse(AnonymousCredentialImpl(AnonymousCredential())))

--- a/src/main/scala/models/settings/staging/JdbcCredentialType.scala
+++ b/src/main/scala/models/settings/staging/JdbcCredentialType.scala
@@ -17,10 +17,13 @@ case class BasicCredential(
   private val user: String     = userSetting.getOrElse(sys.env("ARCANE_FRAMEWORK__JDBC_MERGE_SERVICE_USER"))
   private val password: String = passwordSetting.getOrElse(sys.env("ARCANE_FRAMEWORK__JDBC_MERGE_SERVICE_PASSWORD"))
 
-  def asParameters: Map[String, String] = Map(
-    "user"     -> user,
-    "password" -> password
-  )
+  def asParameters: Map[String, String] =
+    if password.isEmpty then Map("user" -> user)
+    else
+      Map(
+        "user"     -> user,
+        "password" -> password
+      )
 
 /** ADT proxy for BasicCredential
   */

--- a/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
+++ b/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
@@ -54,6 +54,10 @@ trait JdbcMergeServiceClientSettings:
     */
   val connectionUrl: JdbcConnectionUrl
 
+  /** Credential type to be used by JDBC client
+    */
+  val credentialType: JdbcCredentialType
+
   /** Optional extra connection parameters for the merge client (tags, session properties etc.)
     */
   val extraConnectionParameters: Map[String, String]
@@ -85,9 +89,20 @@ trait JdbcMergeServiceClientSettings:
     */
   final def isValid: Boolean = Try(DriverManager.getDriver(connectionUrl)).isSuccess
 
-  final def getConnectionString: String = connectionUrl.withUrlParameters(extraConnectionParameters)
+  final def getConnectionString(catalog: String, schema: String, credential: JdbcCredentialType): String = {
+    val baseUrl = connectionUrl
+      .withDefaultCatalog(catalog)
+      .withDefaultSchema(schema)
+      .withUrlParameters(extraConnectionParameters)
+
+    credential match {
+      case AnonymousCredentialImpl(_)           => baseUrl
+      case BasicCredentialImpl(basicCredential) => baseUrl.withUrlParameters(basicCredential.asParameters)
+    }
+  }
 
 case class DefaultJdbcMergeServiceClientSettings(
+    @key("credentialType") credentialSetting: JdbcCredentialTypeSetting,
     @key("queryRetryMode") queryRetryModeSettings: JdbcQueryRetryModeSettings,
     override val queryRetryBaseDuration: Duration,
     override val queryRetryOnMessageContents: List[String],
@@ -99,3 +114,4 @@ case class DefaultJdbcMergeServiceClientSettings(
   override val connectionUrl: String =
     connectionString.getOrElse(sys.env("ARCANE_FRAMEWORK__MERGE_SERVICE_CONNECTION_URI"))
   override val queryRetryMode: JdbcQueryRetryMode = queryRetryModeSettings.resolveRetryMode
+  override val credentialType: JdbcCredentialType = credentialSetting.resolveCredentialType

--- a/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
+++ b/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
@@ -89,7 +89,7 @@ trait JdbcMergeServiceClientSettings:
     */
   final def isValid: Boolean = Try(DriverManager.getDriver(connectionUrl)).isSuccess
 
-  final def getConnectionString(catalog: String, schema: String, credential: JdbcCredentialType): String = {
+  final def getConnectionString(catalog: String, schema: String, credential: JdbcCredentialType): String =
     val baseUrl = connectionUrl
       .withDefaultCatalog(catalog)
       .withDefaultSchema(schema)
@@ -99,7 +99,6 @@ trait JdbcMergeServiceClientSettings:
       case AnonymousCredentialImpl(_)           => baseUrl
       case BasicCredentialImpl(basicCredential) => baseUrl.withUrlParameters(basicCredential.asParameters)
     }
-  }
 
 case class DefaultJdbcMergeServiceClientSettings(
     @key("credentialType") credentialSetting: JdbcCredentialTypeSetting,

--- a/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
+++ b/src/main/scala/models/settings/staging/JdbcMergeServiceClientSettings.scala
@@ -101,16 +101,14 @@ trait JdbcMergeServiceClientSettings:
     }
 
 case class DefaultJdbcMergeServiceClientSettings(
+    override val connectionUrl: JdbcConnectionUrl,
     @key("credentialType") credentialSetting: JdbcCredentialTypeSetting,
     @key("queryRetryMode") queryRetryModeSettings: JdbcQueryRetryModeSettings,
     override val queryRetryBaseDuration: Duration,
     override val queryRetryOnMessageContents: List[String],
     override val queryRetryScaleFactor: Double,
     override val queryRetryMaxAttempts: Int,
-    override val extraConnectionParameters: Map[String, String],
-    @key("connectionUrl") connectionString: Option[String] = None
+    override val extraConnectionParameters: Map[String, String]
 ) extends JdbcMergeServiceClientSettings derives ReadWriter:
-  override val connectionUrl: String =
-    connectionString.getOrElse(sys.env("ARCANE_FRAMEWORK__MERGE_SERVICE_CONNECTION_URI"))
   override val queryRetryMode: JdbcQueryRetryMode = queryRetryModeSettings.resolveRetryMode
   override val credentialType: JdbcCredentialType = credentialSetting.resolveCredentialType

--- a/src/main/scala/services/merging/JdbcMergeServiceClient.scala
+++ b/src/main/scala/services/merging/JdbcMergeServiceClient.scala
@@ -3,7 +3,13 @@ package services.merging
 
 import logging.ZIOLogAnnotations.*
 import models.app.PluginStreamContext
-import models.settings.staging.{AlwaysImpl, BackfillOnlyImpl, JdbcMergeServiceClientSettings, NeverImpl}
+import models.settings.staging.{
+  AlwaysImpl,
+  BackfillOnlyImpl,
+  JdbcCredentialType,
+  JdbcMergeServiceClientSettings,
+  NeverImpl
+}
 import services.base.*
 import services.merging.maintenance.{*, given}
 import services.metrics.DeclaredMetrics
@@ -40,6 +46,8 @@ trait JdbcTableManager extends TableManager:
   */
 class JdbcMergeServiceClient(
     options: JdbcMergeServiceClientSettings,
+    defaultCatalogName: String,
+    defaultSchemaName: String,
     declaredMetrics: DeclaredMetrics,
     isBackfilling: Boolean
 ) extends MergeServiceClient
@@ -49,7 +57,9 @@ class JdbcMergeServiceClient(
 
   require(options.isValid, "Invalid JDBC url provided for the consumer")
 
-  private lazy val sqlConnection: Connection = DriverManager.getConnection(options.getConnectionString)
+  private lazy val sqlConnection: Connection = DriverManager.getConnection(
+    options.getConnectionString(defaultCatalogName, defaultSchemaName, options.credentialType)
+  )
 
   private val retryPolicy =
     val backoffPolicy =
@@ -160,37 +170,6 @@ class JdbcMergeServiceClient(
       case _ => ZIO.succeed(BatchOptimizationResult(true))
 
 object JdbcMergeServiceClient:
-
-  // See: https://trino.io/docs/current/connector/iceberg.html#iceberg-to-trino-type-mapping
-  extension (icebergType: Type)
-    private def convertType: String = icebergType.typeId() match {
-      case TypeID.BOOLEAN => "BOOLEAN"
-      case TypeID.INTEGER => "INTEGER"
-      case TypeID.LONG    => "BIGINT"
-      case TypeID.FLOAT   => "REAL"
-      case TypeID.DOUBLE  => "DOUBLE"
-      case TypeID.DECIMAL =>
-        s"DECIMAL(${icebergType.asInstanceOf[DecimalType].precision}, ${icebergType.asInstanceOf[DecimalType].scale})"
-      case TypeID.DATE => "DATE"
-      case TypeID.TIME => "TIME(6)"
-      case TypeID.TIMESTAMP
-          if icebergType.isInstanceOf[TimestampType] && icebergType.asInstanceOf[TimestampType].shouldAdjustToUTC() =>
-        "TIMESTAMP(6) WITH TIME ZONE"
-      case TypeID.TIMESTAMP
-          if icebergType.isInstanceOf[TimestampType] && !icebergType.asInstanceOf[TimestampType].shouldAdjustToUTC() =>
-        "TIMESTAMP(6)"
-      case TypeID.STRING => "VARCHAR"
-      case TypeID.UUID   => "UUID"
-      case TypeID.BINARY => "VARBINARY"
-      case TypeID.LIST   => s"ARRAY(${icebergType.asInstanceOf[ListType].elementType().convertType})"
-      // https://trino.io/docs/current/language/types.html#row
-      // struct<1002: colA: optional long, 1003: colB: optional string> -> ROW(colA BIGINT, colB VARCHAR)
-      // nested supported via recursion as well
-      case TypeID.STRUCT =>
-        s"ROW(${icebergType.asInstanceOf[StructType].fields().asScala.map(f => s"${f.name()} ${f.`type`().convertType}").mkString(",")})"
-      case _ => throw new IllegalArgumentException(s"Unsupported type: $icebergType")
-    }
-
   /** The environment type for the JdbcConsumer.
     */
   private type Environment = PluginStreamContext & DeclaredMetrics
@@ -203,11 +182,15 @@ object JdbcMergeServiceClient:
     */
   def apply(
       options: JdbcMergeServiceClientSettings,
+      defaultCatalogName: String,
+      defaultSchemaName: String,
       isBackfilling: Boolean,
       declaredMetrics: DeclaredMetrics
   ): JdbcMergeServiceClient =
     new JdbcMergeServiceClient(
       options,
+      defaultCatalogName,
+      defaultSchemaName,
       declaredMetrics,
       isBackfilling
     )
@@ -223,6 +206,8 @@ object JdbcMergeServiceClient:
           isBackfilling   <- context.isBackfilling.orElseSucceed(false)
         yield JdbcMergeServiceClient(
           context.sink.mergeServiceClient,
+          context.staging.table.stagingCatalogName,
+          context.staging.table.stagingSchemaName,
           isBackfilling,
           declaredMetrics
         )

--- a/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
+++ b/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
@@ -47,6 +47,8 @@ object JdbcMergeServiceClientTests extends ZIOSpecDefault:
   private def getJdbcMergeServiceClient =
     new JdbcMergeServiceClient(
       TestJdbcMergeServiceClientSettings,
+      "iceberg",
+      "test",
       DeclaredMetrics(ArcaneDimensionsProvider("test", false, "test", TestObservabilitySettings)),
       false
     )

--- a/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
+++ b/src/test/scala/tests/services/merging/JdbcMergeServiceClientTests.scala
@@ -1,11 +1,9 @@
 package com.sneaksanddata.arcane.framework
 package tests.services.merging
 
-import models.app.BaseStreamContext
 import models.batches.SynapseLinkMergeBatch
 import models.schemas.ArcaneType.{BooleanType, LongType, StringType}
 import models.schemas.{ArcaneSchema, Field, MergeKeyField}
-import models.settings.staging.{JdbcMergeServiceClientSettings, JdbcQueryRetryMode}
 import services.base.SchemaProvider
 import services.filters.FieldsFilteringService
 import services.merging.*
@@ -16,20 +14,13 @@ import services.merging.maintenance.{
 }
 import services.metrics.{ArcaneDimensionsProvider, DeclaredMetrics}
 import tests.services.merging.JdbcMergeServiceClientTests.test
-import tests.shared.{
-  TestBackfillTableSettings,
-  TestJdbcMergeServiceClientSettings,
-  TestObservabilitySettings,
-  TestSinkSettings,
-  TestTablePropertiesSettings
-}
+import tests.shared.{TestJdbcMergeServiceClientSettings, TestObservabilitySettings, TestTablePropertiesSettings}
 
 import io.trino.jdbc.TrinoDriver
-import org.scalatestplus.easymock.EasyMockSugar
 import org.scalatestplus.easymock.EasyMockSugar.mock
 import zio.test.TestAspect.timeout
 import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assertTrue}
-import zio.{Scope, Task, Unsafe, ZIO}
+import zio.{Scope, Task, ZIO}
 
 import java.sql.Connection
 import java.util.Properties

--- a/src/test/scala/tests/shared/TestJdbcMergeServiceClientSettings.scala
+++ b/src/test/scala/tests/shared/TestJdbcMergeServiceClientSettings.scala
@@ -1,12 +1,20 @@
 package com.sneaksanddata.arcane.framework
 package tests.shared
 
-import models.settings.staging.{JdbcMergeServiceClientSettings, JdbcQueryRetryMode, Never, NeverImpl}
+import models.settings.staging.{
+  BasicCredential,
+  BasicCredentialImpl,
+  JdbcCredentialType,
+  JdbcMergeServiceClientSettings,
+  JdbcQueryRetryMode,
+  Never,
+  NeverImpl
+}
 
 object TestJdbcMergeServiceClientSettings extends JdbcMergeServiceClientSettings:
   /** The connection URL.
     */
-  override val connectionUrl: String = "jdbc:trino://localhost:8080/iceberg/test?user=test"
+  override val connectionUrl: String = "jdbc:trino://localhost:8080"
 
   override val extraConnectionParameters: Map[String, String] = Map()
 
@@ -15,3 +23,12 @@ object TestJdbcMergeServiceClientSettings extends JdbcMergeServiceClientSettings
   override val queryRetryBaseDuration: zio.Duration      = zio.Duration.Zero
   override val queryRetryMaxAttempts: Int                = 1
   override val queryRetryScaleFactor: Double             = 1
+
+  /** Credential type to be used by JDBC client
+    */
+  override val credentialType: JdbcCredentialType = BasicCredentialImpl(
+    BasicCredential(
+      userSetting = Some("test"),
+      passwordSetting = Some("")
+    )
+  )


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/arcane-framework-scala/issues/370

## Scope
- Added enum for JDBC credential types
  - Support Basic and Anonymous by default 
- Refactored `JdbcConnectionExtensions` to allow attaching catalog and schema directly to the JDBC URL and fixed a case when URL has no starting parameters parameter handling logic. 
- Enabled use of default catalog, schema and credentials in the client call to connection string resolver.
