### PR TITLE
WARN logging improvements

### DIFF
--- a/src/main/scala/logging/ZIOLogAnnotations.scala
+++ b/src/main/scala/logging/ZIOLogAnnotations.scala
@@ -89,6 +89,19 @@ object ZIOLogAnnotations:
   def zlog(template: String, values: String*): zio.UIO[Unit] =
     logEnriched(ZIO.log(template.format(values*)), defaultsWithTemplate(template))
 
+  /** Log warning using default annotations
+    *
+    * @param template
+    *   Log message template to use
+    * @param values
+    *   Values for rendering the template
+    * @return
+    *   ZIO Workflow
+    */
+  @unused
+  def zlogWarning(template: String, values: String*): zio.UIO[Unit] =
+    logEnriched(ZIO.logWarning(template.format(values*)), defaultsWithTemplate(template))
+
   /** Log using default and additional custom annotations
     *
     * @param template
@@ -103,6 +116,25 @@ object ZIOLogAnnotations:
   @unused
   def zlog(template: String, annotations: Seq[(LogAnnotation[String], String)], values: String*): zio.UIO[Unit] =
     logEnriched(ZIO.log(template.format(values*)), defaultsWithTemplate(template) ++ annotations)
+
+  /** Log warning using default and additional custom annotations
+    *
+    * @param template
+    *   Log message to record
+    * @param annotations
+    *   ZIO log annotations and values
+    * @param values
+    *   Values for rendering the template
+    * @return
+    *   ZIO Workflow
+    */
+  @unused
+  def zlogWarning(
+      template: String,
+      annotations: Seq[(LogAnnotation[String], String)],
+      values: String*
+  ): zio.UIO[Unit] =
+    logEnriched(ZIO.logWarning(template.format(values*)), defaultsWithTemplate(template) ++ annotations)
 
   /** Log error using default annotations
     *

--- a/src/main/scala/services/merging/JdbcMergeServiceClient.scala
+++ b/src/main/scala/services/merging/JdbcMergeServiceClient.scala
@@ -50,8 +50,8 @@ class JdbcMergeServiceClient(
         case e: SQLException => options.queryRetryOnMessageContents.exists(prefix => e.getMessage.contains(prefix))
         case _               => false
       }).tapOutput { retryInfo =>
-        zlog(
-          s"Statement failed with: ${retryInfo._3.getMessage}, retry #${retryInfo._2}, retry duration ${retryInfo._1.toSeconds}s"
+        zlogWarning(
+          s"Statement failed with: ${retryInfo._3.getMessage}, retry #${retryInfo._2}, retry duration ${retryInfo._1.toMillis} ms"
         )
       }
 


### PR DESCRIPTION
Changes:
- Add ZIO helpers for warning level logging
- Use WARN level on merge service retry attempt logging
- Use ms instead of s for duration