### PR TITLE
[Backfill] Report shard counts and total shards at the start

### DIFF
--- a/src/main/scala/services/backfill/DefaultBackfillSourceDataProvider.scala
+++ b/src/main/scala/services/backfill/DefaultBackfillSourceDataProvider.scala
@@ -2,6 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.backfill
 
 import extensions.ZExtensions.trySetBuffering
+import logging.ZIOLogAnnotations.zlogStream
 import models.backfill.DefaultSourceBackfill
 import models.settings.backfill.BackfillSettings
 import models.settings.sources.SourceBufferingSettings
@@ -61,6 +62,7 @@ abstract class DefaultBackfillSourceDataProvider[WatermarkType <: SourceWatermar
       .flatMap { startFrom =>
         backfillStream(startFrom, snapshotVersion, shards)
           .via(collectShards)
+          .flatMap(v => zlogStream("Prepared total %s shards for the backfill", v.size.toString) *> ZStream.succeed(v))
           .flatMap { bootstrapped =>
             val outputStream = ZStream.fromIterable(bootstrapped.map { case unshaped: DefaultBootstrappedShard =>
               unshaped.copy(

--- a/src/main/scala/services/backfill/DefaultBackfillStateManager.scala
+++ b/src/main/scala/services/backfill/DefaultBackfillStateManager.scala
@@ -1,7 +1,6 @@
 package com.sneaksanddata.arcane.framework
 package services.backfill
 
-import models.app.PluginStreamContext
 import models.backfill.DefaultSourceBackfill
 import models.ddl.CreateTableRequest
 import models.schemas.ArcaneSchema
@@ -9,6 +8,7 @@ import models.sharding.{BootstrappedShard, CompletionShard, StagedShard}
 import services.backfill.base.{BackfillStateManager, ShardFactory, ShardProcessingState}
 import services.iceberg.base.{StagingEntityManager, StagingPropertyManager}
 import services.iceberg.given_Conversion_ArcaneSchema_Schema
+import services.metrics.DeclaredMetrics
 import services.naming.NameGenerator
 
 import zio.{Task, ZIO, ZLayer}
@@ -17,7 +17,8 @@ class DefaultBackfillStateManager(
     stagingEntityManager: StagingEntityManager,
     stagingPropertyManager: StagingPropertyManager,
     shardFactory: ShardFactory,
-    nameGenerator: NameGenerator
+    nameGenerator: NameGenerator,
+    declaredMetrics: DeclaredMetrics
 ) extends BackfillStateManager:
   override type StateImpl = DefaultSourceBackfill
 
@@ -44,14 +45,20 @@ class DefaultBackfillStateManager(
           stagingPropertyManager
             .setProperty(shardTableName, watermarkPropertyName, completionShard.watermark)
         )
-        .map(_ => completionShard)
+        .flatMap { _ =>
+          for _ <- ZIO.succeed(1) @@ declaredMetrics.backfillCombinedShards
+          yield completionShard
+        }
     }
 
   override def commitStagedShard(shard: StagedShard): Task[StagedShard] =
     nameGenerator.getShardTableName(shard).flatMap { shardTableName =>
       stagingPropertyManager
         .setProperty(shardTableName, processingStatePropertyName, ShardProcessingState.STAGED.toString)
-        .map(_ => shard)
+        .flatMap { _ =>
+          for _ <- ZIO.succeed(1) @@ declaredMetrics.backfillStagedShards
+          yield shard
+        }
     }
 
   override def isStaged(shard: BootstrappedShard): Task[Boolean] = for
@@ -89,10 +96,12 @@ object DefaultBackfillStateManager:
       stagingPropertyManager <- ZIO.service[StagingPropertyManager]
       shardFactory           <- ZIO.service[ShardFactory]
       nameGenerator          <- ZIO.service[NameGenerator]
+      declaredMetrics        <- ZIO.service[DeclaredMetrics]
     yield new DefaultBackfillStateManager(
       stagingEntityManager = stagingEntityManager,
       stagingPropertyManager = stagingPropertyManager,
       shardFactory = shardFactory,
-      nameGenerator = nameGenerator
+      nameGenerator = nameGenerator,
+      declaredMetrics = declaredMetrics
     )
   }

--- a/src/main/scala/services/backfill/processors/BackfillCompletionProcessor.scala
+++ b/src/main/scala/services/backfill/processors/BackfillCompletionProcessor.scala
@@ -39,6 +39,7 @@ class BackfillCompletionProcessor(
         _ <- ZIO.attempt(
           TimestampOnlyWatermark.fromJson(shard.watermark).age.toDouble
         ) @@ declaredMetrics.appliedWatermarkAge
+        _ <- zlog("Backfill process completed")
       yield shard.toCompleted
     }
 

--- a/src/main/scala/services/metrics/DeclaredMetrics.scala
+++ b/src/main/scala/services/metrics/DeclaredMetrics.scala
@@ -94,6 +94,12 @@ class DeclaredMetrics:
   val streamingWatermarkAge: Gauge[Double] = Metric
     .gauge(s"$metricsNamespace.watermark.streaming_age")
 
+  val backfillStagedShards: Counter[Int] = Metric
+    .counterInt(s"$metricsNamespace.backfill.shards_staged")
+
+  val backfillCombinedShards: Counter[Int] = Metric
+    .counterInt(s"$metricsNamespace.backfill.shards_combined")
+
 object DeclaredMetrics:
 
   /** Creates a new instance of the DeclaredMetrics.

--- a/src/test/scala/tests/mssql/MsSqlBackfillStreamDataProviderTests.scala
+++ b/src/test/scala/tests/mssql/MsSqlBackfillStreamDataProviderTests.scala
@@ -111,7 +111,8 @@ object MsSqlBackfillStreamDataProviderTests extends ZIOSpecDefault:
             stagingEntityManager,
             stagingPropertyManager,
             new MsSqlShardFactory(nameGenerator),
-            nameGenerator
+            nameGenerator,
+            DeclaredMetrics()
           )
         )
         shaperBuilder <- ZIO.succeed(
@@ -201,7 +202,8 @@ object MsSqlBackfillStreamDataProviderTests extends ZIOSpecDefault:
             stagingEntityManager,
             stagingPropertyManager,
             new MsSqlShardFactory(nameGenerator),
-            nameGenerator
+            nameGenerator,
+            DeclaredMetrics()
           )
         )
         shaperBuilder <- ZIO.succeed(

--- a/src/test/scala/tests/services/backfill/DefaultBackfillOverwriteGraphBuilderTests.scala
+++ b/src/test/scala/tests/services/backfill/DefaultBackfillOverwriteGraphBuilderTests.scala
@@ -48,7 +48,7 @@ final class TestShardFactory(nameGenerator: NameGenerator) extends ShardFactory:
         shard.combinedTableName,
         shard.targetTableName,
         new StreamingBatchQuery {
-          override def query: String = s"INSERT INTO ${shard.combinedTableName} SELECT * FROM ${shardTableName}"
+          override def query: String = s"INSERT INTO ${shard.combinedTableName} SELECT * FROM $shardTableName"
         },
         shard.backfillId
       )
@@ -193,7 +193,8 @@ object DefaultBackfillOverwriteGraphBuilderTests extends ZIOSpecDefault:
           stagingEntityManager,
           stagingPropertyManager,
           shardFactory,
-          nameGenerator
+          nameGenerator,
+          DeclaredMetrics()
         )
       )
       builder <- ZIO.succeed(

--- a/src/test/scala/tests/synapse/SynapseBackfillStreamDataProviderTests.scala
+++ b/src/test/scala/tests/synapse/SynapseBackfillStreamDataProviderTests.scala
@@ -53,7 +53,8 @@ object SynapseBackfillStreamDataProviderTests extends ZIOSpecDefault:
             stagingEntityManager,
             stagingPropertyManager,
             new SynapseShardFactory(nameGenerator),
-            nameGenerator
+            nameGenerator,
+            DeclaredMetrics()
           )
         )
         shaperBuilder <- ZIO.succeed(
@@ -124,7 +125,8 @@ object SynapseBackfillStreamDataProviderTests extends ZIOSpecDefault:
             stagingEntityManager,
             stagingPropertyManager,
             new SynapseShardFactory(nameGenerator),
-            nameGenerator
+            nameGenerator,
+            DeclaredMetrics()
           )
         )
         shaperBuilder <- ZIO.succeed(


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/arcane-framework-scala/issues/256

Approach changed a bit from the issue, will instead report shard counts and total shards, users can then assemble a notebook to watch progress.