### PR TITLE
[Staging] Remove staging table prefix

### DIFF
--- a/src/main/scala/models/settings/staging/StagingTableSettings.scala
+++ b/src/main/scala/models/settings/staging/StagingTableSettings.scala
@@ -11,10 +11,6 @@ import java.util.UUID
   */
 trait StagingTableSettings:
 
-  /** The prefix for the staging table name
-    */
-  val stagingTablePrefix: String
-
   /** The name of the catalog where the staging table is located
     */
   val stagingCatalogName: String
@@ -31,15 +27,7 @@ trait StagingTableSettings:
     */
   val maxRowsPerFile: Option[Int]
 
-  /** Creates a name for the staging table
-    */
-  def newStagingTableName: String =
-    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
-    val id                           = UUID.randomUUID().toString
-    s"${stagingTablePrefix}__${ZonedDateTime.now(ZoneOffset.UTC).format(formatter)}_$id".replace('-', '_')
-
 case class DefaultStagingTableSettings(
-    override val stagingTablePrefix: String,
     override val maxRowsPerFile: Option[Int],
     override val stagingCatalogName: String,
     override val stagingSchemaName: String,

--- a/src/main/scala/services/app/GenericStreamRunnerService.scala
+++ b/src/main/scala/services/app/GenericStreamRunnerService.scala
@@ -24,7 +24,6 @@ import scala.collection.SortedMap
 class GenericStreamRunnerService(
     builder: StreamingGraphBuilder,
     lifetimeService: StreamLifetimeService,
-    stagingDataSettings: StagingTableSettings,
     bootstrapper: StreamBootstrapper,
     tagProvider: MetricTagProvider
 ) extends StreamRunnerService:
@@ -41,9 +40,7 @@ class GenericStreamRunnerService(
       .flatMap(tags =>
         (for
           _ <- zlog("Starting the stream runner")
-          _ <- bootstrapper.cleanupStagingTables(
-            stagingDataSettings.stagingTablePrefix
-          )
+          _ <- bootstrapper.cleanupStagingTables
           _ <- bootstrapper.cleanupOutdatedBackfill
 
           _ <- bootstrapper.createTargetTable
@@ -67,8 +64,7 @@ object GenericStreamRunnerService:
 
   /** The required environment for the GenericStreamRunnerService.
     */
-  type Environment = StreamLifetimeService & StreamingGraphBuilder & PluginStreamContext & StreamBootstrapper &
-    MetricTagProvider
+  type Environment = StreamLifetimeService & StreamingGraphBuilder & StreamBootstrapper & MetricTagProvider
 
   /** Creates a new instance of the GenericStreamRunnerService class.
     *
@@ -82,14 +78,12 @@ object GenericStreamRunnerService:
   def apply(
       builder: StreamingGraphBuilder,
       lifetimeService: StreamLifetimeService,
-      stagingDataSettings: StagingTableSettings,
       bootstrapper: StreamBootstrapper,
       tagProvider: MetricTagProvider
   ): GenericStreamRunnerService =
     new GenericStreamRunnerService(
       builder,
       lifetimeService,
-      stagingDataSettings,
       bootstrapper,
       tagProvider
     )
@@ -101,13 +95,11 @@ object GenericStreamRunnerService:
       for
         lifetimeService <- ZIO.service[StreamLifetimeService]
         builder         <- ZIO.service[StreamingGraphBuilder]
-        context         <- ZIO.service[PluginStreamContext]
         bootstrapper    <- ZIO.service[StreamBootstrapper]
         tagProvider     <- ZIO.service[MetricTagProvider]
       yield GenericStreamRunnerService(
         builder,
         lifetimeService,
-        context.staging.table,
         bootstrapper,
         tagProvider
       )

--- a/src/main/scala/services/bootstrap/DefaultStreamBootstrapper.scala
+++ b/src/main/scala/services/bootstrap/DefaultStreamBootstrapper.scala
@@ -22,10 +22,11 @@ class DefaultStreamBootstrapper(
     stagingSettings: StagingSettings,
     isBackfilling: Boolean
 ) extends StreamBootstrapper:
-  override def cleanupStagingTables(prefix: String): Task[Unit] =
-    zlog("Looking for staging tables from previous run, using prefix %s", prefix) *> stagingEntityManager.deleteTables(
-      prefix
-    )
+  override def cleanupStagingTables: Task[Unit] = for
+    prefix <- nameGenerator.getStagingTablePrefix
+    _ <- zlog("Looking for staging tables from previous run, using prefix %s", prefix)
+    _ <- stagingEntityManager.deleteTables(prefix)
+  yield ()
 
   override def cleanupOutdatedBackfill: Task[Unit] = for _ <- ZIO.unless(isBackfilling) {
       for

--- a/src/main/scala/services/bootstrap/DefaultStreamBootstrapper.scala
+++ b/src/main/scala/services/bootstrap/DefaultStreamBootstrapper.scala
@@ -24,8 +24,8 @@ class DefaultStreamBootstrapper(
 ) extends StreamBootstrapper:
   override def cleanupStagingTables: Task[Unit] = for
     prefix <- nameGenerator.getStagingTablePrefix
-    _ <- zlog("Looking for staging tables from previous run, using prefix %s", prefix)
-    _ <- stagingEntityManager.deleteTables(prefix)
+    _      <- zlog("Looking for staging tables from previous run, using prefix %s", prefix)
+    _      <- stagingEntityManager.deleteTables(prefix)
   yield ()
 
   override def cleanupOutdatedBackfill: Task[Unit] = for _ <- ZIO.unless(isBackfilling) {

--- a/src/main/scala/services/bootstrap/base/StreamBootstrapper.scala
+++ b/src/main/scala/services/bootstrap/base/StreamBootstrapper.scala
@@ -4,9 +4,8 @@ package services.bootstrap.base
 import zio.Task
 
 trait StreamBootstrapper:
-  /** Cleans up streaming staging tables left after previous run. This method is used to ensure that the
-    * staging tables are cleaned up after the streaming job restart.
-    *.
+  /** Cleans up streaming staging tables left after previous run. This method is used to ensure that the staging tables
+    * are cleaned up after the streaming job restart. .
     */
   def cleanupStagingTables: Task[Unit]
 

--- a/src/main/scala/services/bootstrap/base/StreamBootstrapper.scala
+++ b/src/main/scala/services/bootstrap/base/StreamBootstrapper.scala
@@ -4,14 +4,11 @@ package services.bootstrap.base
 import zio.Task
 
 trait StreamBootstrapper:
-  /** Cleans up the staging tables in the specific catalog by table name prefix. This method is used to ensure that the
+  /** Cleans up streaming staging tables left after previous run. This method is used to ensure that the
     * staging tables are cleaned up after the streaming job restart.
-    *
-    * The prefix of the staging table name.
-    * @return
-    *   The list of tables.
+    *.
     */
-  def cleanupStagingTables(prefix: String): Task[Unit]
+  def cleanupStagingTables: Task[Unit]
 
   /** Creates the target table.
     *

--- a/src/main/scala/services/naming/DefaultNameGenerator.scala
+++ b/src/main/scala/services/naming/DefaultNameGenerator.scala
@@ -49,7 +49,7 @@ final class DefaultNameGenerator(
 
   override def getStagingTableName: Task[String] = for
     tableId <- ZIO.succeed(UUID.randomUUID().toString.replace("-", "_"))
-    prefix <- getStagingTablePrefix
+    prefix  <- getStagingTablePrefix
   yield s"${prefix}__$tableId"
 
 object DefaultNameGenerator:

--- a/src/main/scala/services/naming/DefaultNameGenerator.scala
+++ b/src/main/scala/services/naming/DefaultNameGenerator.scala
@@ -9,6 +9,8 @@ import models.sharding.SourceShard
 
 import zio.{Task, ZIO, ZLayer}
 
+import java.util.UUID
+
 final class DefaultNameGenerator(
     sinkSettings: SinkSettings,
     backfillId: BackfillIdentifier,
@@ -43,7 +45,12 @@ final class DefaultNameGenerator(
     shard.shardId
   ).mkString("__")
 
-  override def getStagingTableName: Task[String] = ???
+  override def getStagingTablePrefix: Task[String] = ZIO.succeed(s"stream__${nameSafeStreamId}__stage")
+
+  override def getStagingTableName: Task[String] = for
+    tableId <- ZIO.succeed(UUID.randomUUID().toString.replace("-", "_"))
+    prefix <- getStagingTablePrefix
+  yield s"${prefix}__$tableId"
 
 object DefaultNameGenerator:
   val layer = ZLayer {

--- a/src/main/scala/services/naming/NameGenerator.scala
+++ b/src/main/scala/services/naming/NameGenerator.scala
@@ -5,41 +5,33 @@ import models.sharding.SourceShard
 
 import zio.Task
 
-/**
- * Table name generator that ensures all names are bound to stream identifier
- */
+/** Table name generator that ensures all names are bound to stream identifier
+  */
 trait NameGenerator:
-  /**
-   * Generate name for a new staging table (streaming)
-   */
+  /** Generate name for a new staging table (streaming)
+    */
   def getStagingTableName: Task[String]
 
-  /**
-   * Get prefix used for all staging tables (streaming)
-   */
+  /** Get prefix used for all staging tables (streaming)
+    */
   def getStagingTablePrefix: Task[String]
 
-  /**
-   * Generate name for a new backfill table (overwrite and merge)
-   */
+  /** Generate name for a new backfill table (overwrite and merge)
+    */
   def getBackfillTableName: Task[String]
 
-  /**
-   * Get prefix used for all staging tables (backfill)
-   */
+  /** Get prefix used for all staging tables (backfill)
+    */
   def getBackfillTablesPrefix: Task[String]
 
-  /**
-   * Generate name for the provided backfill source shard
-   */
+  /** Generate name for the provided backfill source shard
+    */
   def getShardTableName(shard: SourceShard): Task[String]
 
-  /**
-   * Generate target name (proxied from SinkSettings).
-   */
+  /** Generate target name (proxied from SinkSettings).
+    */
   def getTargetTableName: Task[String]
 
-  /**
-   * Generate target name for JDBC client.
-   */
+  /** Generate target name for JDBC client.
+    */
   def getTargetTableFullName: Task[String]

--- a/src/main/scala/services/naming/NameGenerator.scala
+++ b/src/main/scala/services/naming/NameGenerator.scala
@@ -1,15 +1,45 @@
 package com.sneaksanddata.arcane.framework
 package services.naming
 
-import models.settings.{BackfillIdentifier, StreamIdentifier}
 import models.sharding.SourceShard
 
 import zio.Task
 
+/**
+ * Table name generator that ensures all names are bound to stream identifier
+ */
 trait NameGenerator:
+  /**
+   * Generate name for a new staging table (streaming)
+   */
   def getStagingTableName: Task[String]
+
+  /**
+   * Get prefix used for all staging tables (streaming)
+   */
+  def getStagingTablePrefix: Task[String]
+
+  /**
+   * Generate name for a new backfill table (overwrite and merge)
+   */
   def getBackfillTableName: Task[String]
+
+  /**
+   * Get prefix used for all staging tables (backfill)
+   */
   def getBackfillTablesPrefix: Task[String]
+
+  /**
+   * Generate name for the provided backfill source shard
+   */
   def getShardTableName(shard: SourceShard): Task[String]
+
+  /**
+   * Generate target name (proxied from SinkSettings).
+   */
   def getTargetTableName: Task[String]
+
+  /**
+   * Generate target name for JDBC client.
+   */
   def getTargetTableFullName: Task[String]

--- a/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
+++ b/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
@@ -130,7 +130,7 @@ object StagingProcessor:
         catalogWriter      <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
         stagedBatchFactory <- ZIO.service[StagedBatchFactory]
         declaredMetrics    <- ZIO.service[DeclaredMetrics]
-        nameGenerator <- ZIO.service[NameGenerator]
+        nameGenerator      <- ZIO.service[NameGenerator]
       yield StagingProcessor(
         context.sink.targetTableFullName,
         context.staging.icebergCatalog,

--- a/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
+++ b/src/main/scala/services/streaming/processors/transformers/StagingProcessor.scala
@@ -6,12 +6,12 @@ import models.app.PluginStreamContext
 import models.batches.{MergeableBatch, StagedVersionedBatch}
 import models.schemas.{ArcaneSchema, DataRow}
 import models.settings.iceberg.IcebergCatalogSettings
-import models.settings.staging.StagingTableSettings
 import services.iceberg.base.CatalogWriter
 import services.iceberg.given_Conversion_ArcaneSchema_Schema
 import services.metrics.DeclaredMetrics
 import services.metrics.DeclaredMetrics.*
-import services.streaming.base.{StreamingRowGroupTransformer, StagedBatchProcessor}
+import services.naming.NameGenerator
+import services.streaming.base.{StagedBatchProcessor, StreamingRowGroupTransformer}
 import services.streaming.batching.StagedBatchFactory
 
 import org.apache.iceberg.rest.RESTCatalog
@@ -22,12 +22,12 @@ import zio.{Chunk, Task, ZIO, ZLayer}
 import scala.collection.parallel.CollectionConverters.*
 
 class StagingProcessor(
-    stagingDataSettings: StagingTableSettings,
     targetTableFullName: String,
     icebergCatalogSettings: IcebergCatalogSettings,
     catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
     batchFactory: StagedBatchFactory,
-    declaredMetrics: DeclaredMetrics
+    declaredMetrics: DeclaredMetrics,
+    nameGenerator: NameGenerator
 ) extends StreamingRowGroupTransformer:
 
   type OutgoingElement = StagedBatchProcessor#BatchType
@@ -87,11 +87,11 @@ class StagingProcessor(
   ): Task[Option[StagedVersionedBatch & MergeableBatch]] =
     for staged <- ZIO.when(rows.nonEmpty) {
         for
-          tableName <- ZIO.succeed(stagingDataSettings.newStagingTableName)
+          tableName <- nameGenerator.getStagingTableName
           table <- ZIO.when(rows.nonEmpty)(
             catalogWriter.write(
               rows,
-              stagingDataSettings.newStagingTableName,
+              tableName,
               rowSchema,
               Seq(getAnnotation("processor", "StagingProcessor"))
             )
@@ -104,24 +104,24 @@ class StagingProcessor(
 object StagingProcessor:
 
   def apply(
-      stagingDataSettings: StagingTableSettings,
       targetTableFullName: String,
       icebergCatalogSettings: IcebergCatalogSettings,
       catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
       batchFactory: StagedBatchFactory,
-      declaredMetrics: DeclaredMetrics
+      declaredMetrics: DeclaredMetrics,
+      nameGenerator: NameGenerator
   ): StagingProcessor =
     new StagingProcessor(
-      stagingDataSettings,
       targetTableFullName,
       icebergCatalogSettings,
       catalogWriter,
       batchFactory,
-      declaredMetrics
+      declaredMetrics,
+      nameGenerator
     )
 
   type Environment = PluginStreamContext & CatalogWriter[RESTCatalog, Table, Schema] & StagedBatchFactory &
-    DeclaredMetrics
+    DeclaredMetrics & NameGenerator
 
   val layer: ZLayer[Environment, Nothing, StagingProcessor] =
     ZLayer {
@@ -130,12 +130,13 @@ object StagingProcessor:
         catalogWriter      <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
         stagedBatchFactory <- ZIO.service[StagedBatchFactory]
         declaredMetrics    <- ZIO.service[DeclaredMetrics]
+        nameGenerator <- ZIO.service[NameGenerator]
       yield StagingProcessor(
-        context.staging.table,
         context.sink.targetTableFullName,
         context.staging.icebergCatalog,
         catalogWriter,
         stagedBatchFactory,
-        declaredMetrics
+        declaredMetrics,
+        nameGenerator
       )
     }

--- a/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
+++ b/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
@@ -126,7 +126,7 @@ object StagingProcessorTests extends ZIOSpecDefault:
           .rechunk(1)
           .via(stagingProcessor.process(testSchema))
           .run(ZSink.collectAll)
-      } yield assertTrue(result.size == 2 && result.head.name.startsWith("staging_table__"))
+      } yield assertTrue(result.size == 2 && result.head.name.startsWith("stream__staging_processor_tests__stage"))
     }
   ).provide(
     IcebergEntityManager.stagingLayer,

--- a/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
+++ b/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
@@ -16,9 +16,9 @@ import services.iceberg.base.CatalogWriter
 import services.iceberg.{IcebergEntityManager, IcebergS3CatalogWriter}
 import services.metrics.DeclaredMetrics
 import services.streaming.processors.transformers.StagingProcessor
+import services.naming.DefaultNameGenerator
 import tests.shared.*
 
-import com.sneaksanddata.arcane.framework.services.naming.DefaultNameGenerator
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.stream.{ZSink, ZStream}

--- a/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
+++ b/src/test/scala/tests/services/streaming/processors/transformers/StagingProcessorTests.scala
@@ -18,6 +18,7 @@ import services.metrics.DeclaredMetrics
 import services.streaming.processors.transformers.StagingProcessor
 import tests.shared.*
 
+import com.sneaksanddata.arcane.framework.services.naming.DefaultNameGenerator
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.stream.{ZSink, ZStream}
@@ -50,13 +51,20 @@ object StagingProcessorTests extends ZIOSpecDefault:
   )
   private val getProcessor = for {
     catalogWriterService <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
+    nameGenerator <- ZIO.succeed(
+      new DefaultNameGenerator(
+        sinkSettings = TestSinkSettings,
+        backfillId = "",
+        streamId = "staging-processor-tests"
+      )
+    )
     stagingProcessor = StagingProcessor(
-      TestStagingTableSettings,
       TestSinkSettings.targetTableFullName,
       TestIcebergStagingSettings,
       catalogWriterService,
       new TestStagedBatchFactory(),
-      DeclaredMetrics()
+      DeclaredMetrics(),
+      nameGenerator
     )
   } yield stagingProcessor
 

--- a/src/test/scala/tests/shared/TestStagingTableSettings.scala
+++ b/src/test/scala/tests/shared/TestStagingTableSettings.scala
@@ -6,6 +6,5 @@ import models.settings.staging.StagingTableSettings
 object TestStagingTableSettings extends StagingTableSettings:
   override val stagingCatalogName: String  = "demo"
   override val stagingSchemaName: String   = "test"
-  override val stagingTablePrefix          = "staging_table"
   override val isUnifiedSchema: Boolean    = false
   override val maxRowsPerFile: Option[Int] = Some(10000)


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/arcane-framework-scala/issues/388

Staging tables now use NameGenerator and source prefix uniqueness from stream identifier.