### PR TITLE
[Backfill] Prevent overcommitting data to shards on backfill restart

### DIFF
--- a/src/main/scala/services/backfill/DefaultBackfillStateManager.scala
+++ b/src/main/scala/services/backfill/DefaultBackfillStateManager.scala
@@ -34,7 +34,8 @@ class DefaultBackfillStateManager(
 
   override def prepareShardStage(shard: BootstrappedShard, schema: ArcaneSchema): Task[Unit] = for
     shardTableName <- nameGenerator.getShardTableName(shard)
-    _              <- stagingEntityManager.createTable(CreateTableRequest(shardTableName, schema, false))
+    // replace = true ensures we do not append to the previously created shard table, in case a backfill was interrupted
+    _ <- stagingEntityManager.createTable(CreateTableRequest(shardTableName, schema, true))
   yield ()
 
   override def commitCombinedShard(completionShard: CompletionShard): Task[CompletionShard] =

--- a/src/test/scala/tests/services/backfill/DefaultBackfillOverwriteGraphBuilderTests.scala
+++ b/src/test/scala/tests/services/backfill/DefaultBackfillOverwriteGraphBuilderTests.scala
@@ -345,6 +345,81 @@ object DefaultBackfillOverwriteGraphBuilderTests extends ZIOSpecDefault:
         expectedRowsInTarget <- ZStream.fromIterable(shards).flatMap(_.shardStream._1).runCount
         rowsInTarget         <- getRowsInTarget(trinoConnection, "iceberg.test.interrupted_1_backfill_stream")
       yield assertTrue(rowsInTarget == expectedRowsInTarget)
+    },
+    test("prevents overcommitting data to shards on backfill restart when a shard is partially staged") {
+      for
+        trinoConnection <- newTrinoConnection
+        (_, _, backfillTableName, shardTableNames) <- runBackfill(
+          "iceberg.test.overcommit_backfill_stream",
+          "test_overcommit_prevention"
+        )
+        // now simulate interruption where shard1 was partially staged, but backfill was interrupted and restarted
+
+        // truncate target
+        _ <- ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(
+              ZIO.attempt(trinoConnection.prepareStatement("truncate table iceberg.test.overcommit_backfill_stream"))
+            )
+            .map(_.execute())
+        }
+        // truncate combined
+        _ <- ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(
+              ZIO.attempt(
+                trinoConnection.prepareStatement(
+                  s"truncate table iceberg.test.$backfillTableName"
+                )
+              )
+            )
+            .map(_.execute())
+        }
+        // drop shard2 and shard3 tables
+        _ <- ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(
+              ZIO.attempt(
+                trinoConnection.prepareStatement(s"drop table iceberg.test.${shardTableNames(1)}")
+              )
+            )
+            .map(_.execute())
+        }
+        _ <- ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(
+              ZIO.attempt(
+                trinoConnection.prepareStatement(s"drop table iceberg.test.${shardTableNames(2)}")
+              )
+            )
+            .map(_.execute())
+        }
+        // simulate partial staging on shard1: delete 1 row from it to simulate partial write during interruption
+        _ <- ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(
+              ZIO.attempt(
+                trinoConnection.prepareStatement(s"delete from iceberg.test.${shardTableNames.head} where colB = 1")
+              )
+            )
+            .map(_.execute())
+        }
+
+        stagingPropertyManager <- ZIO.service[StagingPropertyManager]
+        // remove processing state from shard1
+        _ <- stagingPropertyManager.setProperty(
+          shardTableNames.head,
+          "processing-state",
+          ""
+        )
+        // re-run and expect identical result to a full backfill (without duplicated data in shard1)
+        (_, shards, _, _) <- runBackfill(
+          "iceberg.test.overcommit_backfill_stream",
+          "test_overcommit_prevention"
+        )
+        expectedRowsInTarget <- ZStream.fromIterable(shards).flatMap(_.shardStream._1).runCount
+        rowsInTarget         <- getRowsInTarget(trinoConnection, "iceberg.test.overcommit_backfill_stream")
+      yield assertTrue(rowsInTarget == expectedRowsInTarget)
     }
   ).provide(
     writerLayer,


### PR DESCRIPTION
Explain: if a backfill is interrupted while shard is staged, we will start staging by re-downloading entire shard. In this case we want shard table to be re-created, otherwise we'll add extra rows to it and corrupt target for sources that do not deduplicate shard data.