### PR TITLE
WIP: implement merge key row modification

### DIFF
--- a/src/main/resources/get_select_all_query.sql
+++ b/src/main/resources/get_select_all_query.sql
@@ -2,6 +2,6 @@ declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
 
 SELECT
 {ChangeTrackingColumnsStatement},
-@currentVersion AS 'ChangeTrackingVersion',
-lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}]
+@currentVersion AS 'ChangeTrackingVersion'
+{OptionalMergeKeyColumnExpression}
 FROM [{dbName}].[{schema}].[{tableName}] tq

--- a/src/main/resources/get_select_delta_query.sql
+++ b/src/main/resources/get_select_delta_query.sql
@@ -1,6 +1,6 @@
 SELECT
 {ChangeTrackingColumnsStatement},
-cast({lastId} as bigint) AS 'ChangeTrackingVersion',
-lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}]
+cast({lastId} as bigint) AS 'ChangeTrackingVersion'
+{OptionalMergeKeyColumnExpression}
 FROM [{dbName}].[{schema}].[{tableName}] tq
 RIGHT JOIN (SELECT ct.* FROM CHANGETABLE (CHANGES [{dbName}].[{schema}].[{tableName}], {lastId}) ct ) ct ON {ChangeTrackingMatchStatement}

--- a/src/main/scala/models/batches/BlobBatchCommons.scala
+++ b/src/main/scala/models/batches/BlobBatchCommons.scala
@@ -36,17 +36,28 @@ object BlobBatchCommons:
     )
   )
 
-  def enrichBatchRow(row: DataRow, version: Long, primaryKeys: Seq[String], hasher: MessageDigest): DataRow =
-    row ++ Seq(
-      DataCell(
-        name = MergeKeyField.name,
-        Type = MergeKeyField.fieldType,
-        value = getMergeKeyValue(row, primaryKeys, hasher)
-      ),
-      // merge query requires a versionField to ensure rows are updated correctly
-      DataCell(
-        name = BlobBatchCommons.versionField.name,
-        Type = BlobBatchCommons.versionField.fieldType,
-        value = version
-      )
+  def addVersion(row: DataRow, version: Long): DataRow =
+    row :+ DataCell(
+      name = BlobBatchCommons.versionField.name,
+      Type = BlobBatchCommons.versionField.fieldType,
+      value = version
     )
+
+  def addLegacyMergeKey(row: DataRow, primaryKeys: Seq[String], hasher: MessageDigest): DataRow =
+    row :+ DataCell(
+      name = MergeKeyField.name,
+      Type = MergeKeyField.fieldType,
+      value = getMergeKeyValue(row, primaryKeys, hasher)
+    )
+
+  def enrichBatchRow(
+      row: DataRow,
+      version: Long,
+      primaryKeys: Seq[String],
+      hasher: MessageDigest,
+      includeLegacyMergeKey: Boolean
+  ): DataRow =
+    val rowWithLegacyMergeKey =
+      if includeLegacyMergeKey then addLegacyMergeKey(row, primaryKeys, hasher)
+      else row
+    addVersion(rowWithLegacyMergeKey, version)

--- a/src/main/scala/models/cdm/CSVParser.scala
+++ b/src/main/scala/models/cdm/CSVParser.scala
@@ -92,25 +92,43 @@ object CSVParser:
     regex.replaceSomeIn(csvLine, m => Some(m.matched.replace("\n", ""))).replace("\r", "")
   }
 
-given Conversion[(String, ArcaneSchema), DataRow] with
   private val arcaneMergeKeyFieldName = "Id"
 
-  override def apply(schemaBoundCsvLine: (String, ArcaneSchema)): DataRow = schemaBoundCsvLine match
-    case (csvLine, schema) =>
-      val parsed = CSVParser.parseCsvLine(line = csvLine, headerCount = schema.size - SimpleCdmModel.systemFieldCount)
+  def parseCSVLineToRow(
+      csvLine: String,
+      schema: ArcaneSchema,
+      includeLegacyMergeKey: Boolean
+  ): DataRow =
+    val sourceSchema = schema.filterNot(_.name.equalsIgnoreCase(MergeKeyField.name))
 
-      val mergeKeyIndex =
-        schema.zipWithIndex.find(v => v._1.name.toLowerCase() == arcaneMergeKeyFieldName.toLowerCase())
-      val mergeKeyValue = mergeKeyIndex
-        .map(v => parsed(v._2))
-        .getOrElse(throw Exception(s"Primary key $arcaneMergeKeyFieldName not found in schema"))
+    val parsed = CSVParser.parseCsvLine(
+      line = csvLine,
+      headerCount = sourceSchema.size
+    )
 
-      parsed.zipWithIndex
-        .map { (fieldValue, index) =>
-          val field = schema(index)
-          DataCell(name = field.name, Type = field.fieldType, value = fieldValue)
-        }
-        .concat(
-          Seq(DataCell(name = MergeKeyField.name, Type = MergeKeyField.fieldType, value = mergeKeyValue))
+    val row = parsed.zipWithIndex
+      .map { (fieldValue, index) =>
+        val field = sourceSchema(index)
+        DataCell(
+          name = field.name,
+          Type = field.fieldType,
+          value = fieldValue
         )
-        .toList
+      }
+
+    val newRow = if includeLegacyMergeKey then
+      val mergeKeyValue = row
+        .find(_.name.equalsIgnoreCase(arcaneMergeKeyFieldName))
+        .map(_.value)
+        .getOrElse(
+          throw new Exception(s"Primary key $arcaneMergeKeyFieldName not found in parsed row")
+        )
+      val mergeKeyCell = DataCell(
+        name = MergeKeyField.name,
+        Type = MergeKeyField.fieldType,
+        value = mergeKeyValue
+      )
+      row.appended(mergeKeyCell)
+    else row
+
+    newRow.toList

--- a/src/main/scala/models/cdm/SimpleCdmModel.scala
+++ b/src/main/scala/models/cdm/SimpleCdmModel.scala
@@ -69,18 +69,12 @@ given Conversion[IndexedSimpleCdmAttribute, IndexedField] with
 
 given Conversion[SimpleCdmEntity, ArcaneSchema] with
   override def apply(entity: SimpleCdmEntity): ArcaneSchema =
-    val baseSchema = entity.attributes
+    entity.attributes
       .foldLeft((ArcaneSchema.empty(), 0)) { case ((agg, fieldIndex), attribute) =>
         val indexedAttr: IndexedField = (attribute, fieldIndex)
         (agg.addIndexedField(indexedAttr.name, indexedAttr.fieldType, indexedAttr.fieldId), fieldIndex + 1)
       }
       ._1
 
-    baseSchema.addIndexedField(MergeKeyField.name, MergeKeyField.fieldType, baseSchema.length)
-
 object SimpleCdmModel:
-  // number of fields in the schema of each entity which do not originate from CDM
-  // currently MergeKeyField only
-  val systemFieldCount: Int = 1
-
   def apply(json: String): SimpleCdmModel = read[SimpleCdmModel](json)

--- a/src/main/scala/models/schemas/ArcaneSchema.scala
+++ b/src/main/scala/models/schemas/ArcaneSchema.scala
@@ -122,6 +122,8 @@ class ArcaneSchema(fields: Seq[ArcaneSchemaField]) extends Seq[ArcaneSchemaField
 
     maybeMergeKey.get
 
+  def nextFieldId: Int = fields.collect { case field: IndexedArcaneSchemaField => field.fieldId }.max + 1
+
   def apply(i: Int): ArcaneSchemaField = fields(i)
 
   def length: Int = fields.length
@@ -170,3 +172,8 @@ given CanAdd[ArcaneSchema] with
     def addIndexedField(fieldName: String, fieldType: ArcaneType, fieldId: Int): ArcaneSchema = fieldName match
       case MergeKeyField.name => a :+ IndexedMergeKeyField(fieldId)
       case _                  => a :+ IndexedField(fieldName, fieldType, fieldId)
+
+    def addIndexedField(fieldName: String, fieldType: ArcaneType): ArcaneSchema =
+      if a.isIndexed
+      then addIndexedField(fieldName, fieldType, a.nextFieldId)
+      else a

--- a/src/main/scala/models/settings/sources/DataRowSchemaVersion.scala
+++ b/src/main/scala/models/settings/sources/DataRowSchemaVersion.scala
@@ -1,0 +1,10 @@
+package com.sneaksanddata.arcane.framework
+package models.settings.sources
+
+import upickle.ReadWriter
+import upickle.default.*
+
+enum DataRowSchemaVersion derives ReadWriter:
+  case V0, V1
+
+  def usesCommonMergeKey: Boolean = this == V1

--- a/src/main/scala/models/settings/sources/StreamSourceSettings.scala
+++ b/src/main/scala/models/settings/sources/StreamSourceSettings.scala
@@ -14,3 +14,7 @@ trait StreamSourceSettings:
   val buffering: SourceBufferingSettings
 
   val fieldSelectionRule: FieldSelectionRuleSettings
+
+  val modifications: DataRowModificationSettings = DefaultDataRowModificationSettings(Seq.empty)
+
+  val dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -1,7 +1,39 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
-import models.schemas.ArcaneSchema
-import services.streaming.base.{JsonWatermark, SourceWatermark}
+import models.schemas.{ArcaneSchema, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
+import models.settings.sources.DataRowModification
+
+import zio.{Task, ZIO}
 
 trait StreamingSource extends SchemaProvider[ArcaneSchema] with ShardProvider
+
+abstract class DefaultStreamingSource(
+    protected val modifications: Seq[DataRowModification]
+) extends StreamingSource {
+  protected val getSourceSchema: Task[ArcaneSchema]
+
+  protected def applyDataRowModification(
+      row: DataRow,
+      modification: DataRowModification
+  ): Task[DataRow]
+
+  protected def applySchemaModification(
+      schema: ArcaneSchema,
+      modification: DataRowModification
+  ): Task[ArcaneSchema]
+
+  final def applyDataRowModifications(row: DataRow): Task[DataRow] =
+    ZIO.foldLeft(modifications)(row)(applyDataRowModification)
+
+  final def applySchemaModifications(schema: ArcaneSchema): Task[ArcaneSchema] =
+    ZIO.foldLeft(modifications)(schema)(applySchemaModification)
+
+//  final override lazy val getSchema: Task[ArcaneSchema] = for
+//    source <- getSourceSchema
+//    ext    <- getSchemaExtensions(Seq.empty)
+//  yield source.appendedAll(ext)
+
+  final override lazy val getSchema: Task[ArcaneSchema] =
+    getSourceSchema.flatMap(applySchemaModifications)
+}

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -1,7 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
-import models.schemas.*
+import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
 import models.settings.sources.{DataRowModification, DataRowSchemaVersion, SurrogateMergeKeyImpl}
 
 import zio.{Task, ZIO}
@@ -49,13 +49,9 @@ abstract class DefaultStreamingSource(
 
       val newSchema =
         if schema.isIndexed then
-          val nextFieldId = schema.collect { case field: IndexedArcaneSchemaField =>
-            field.fieldId
-          }.max + 1
           schema.addIndexedField(
             MergeKeyField.name,
-            MergeKeyField.fieldType,
-            nextFieldId
+            MergeKeyField.fieldType
           )
         else
           schema.addField(

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -1,7 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
-import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
+import models.schemas.*
 import models.settings.sources.{DataRowModification, DataRowSchemaVersion, SurrogateMergeKeyImpl}
 
 import zio.{Task, ZIO}
@@ -46,12 +46,24 @@ abstract class DefaultStreamingSource(
     case SurrogateMergeKeyImpl(_)
         if dataRowSchemaVersion.usesCommonMergeKey &&
           !schema.exists(_.name.equalsIgnoreCase(MergeKeyField.name)) =>
-      ZIO.succeed(
-        schema.addField(
-          MergeKeyField.name,
-          MergeKeyField.fieldType
-        )
-      )
+
+      val newSchema =
+        if schema.isIndexed then
+          val nextFieldId = schema.collect { case field: IndexedArcaneSchemaField =>
+            field.fieldId
+          }.max + 1
+          schema.addIndexedField(
+            MergeKeyField.name,
+            MergeKeyField.fieldType,
+            nextFieldId
+          )
+        else
+          schema.addField(
+            MergeKeyField.name,
+            MergeKeyField.fieldType
+          )
+
+      ZIO.succeed(newSchema)
     case _ => ZIO.succeed(schema)
 
   final def applyDataRowModifications(row: DataRow): Task[DataRow] =

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -67,10 +67,17 @@ abstract class DefaultStreamingSource(
       )
 
   private def createMergeKey(keyValues: Seq[Any]): String =
-    val input = keyValues.map(_.toString.take(128)).mkString("#")
+    val input = keyValues
+      .map {
+        case s: String => s
+        case null      => throw new IllegalArgumentException("PK value must not be null")
+        case other     => throw new UnsupportedOperationException(s"Unsupported PK type: ${other.getClass.getName}")
+      }
+      .mkString("#")
+
     val digest = MessageDigest
       .getInstance("SHA-256")
-      .digest(input.getBytes(StandardCharsets.UTF_16LE))
+      .digest(input.getBytes(StandardCharsets.UTF_8))
 
     HexFormat.of().formatHex(digest)
 }

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -1,27 +1,40 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
-import models.schemas.{ArcaneSchema, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
-import models.settings.sources.DataRowModification
+import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
+import models.settings.sources.{DataRowModification, SurrogateMergeKeyImpl}
 
 import zio.{Task, ZIO}
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.HexFormat
+
 trait StreamingSource extends SchemaProvider[ArcaneSchema] with ShardProvider
+
+trait PrimaryKeyProvider:
+  protected def primaryKeyNames: Task[Seq[String]]
 
 abstract class DefaultStreamingSource(
     protected val modifications: Seq[DataRowModification]
-) extends StreamingSource {
-  protected val getSourceSchema: Task[ArcaneSchema]
+) extends StreamingSource
+    with PrimaryKeyProvider {
+  protected def getSourceSchema: Task[ArcaneSchema]
 
   protected def applyDataRowModification(
       row: DataRow,
       modification: DataRowModification
-  ): Task[DataRow]
+  ): Task[DataRow] = modification match
+    case SurrogateMergeKeyImpl(_) => addSurrogateMergeKey(row)
+    case _                        => ZIO.succeed(row)
 
   protected def applySchemaModification(
       schema: ArcaneSchema,
       modification: DataRowModification
-  ): Task[ArcaneSchema]
+  ): Task[ArcaneSchema] = modification match
+    case SurrogateMergeKeyImpl(_) if !schema.exists(_.name.equalsIgnoreCase(MergeKeyField.name)) =>
+      ZIO.succeed(schema.addField(MergeKeyField.name, MergeKeyField.fieldType))
+    case _ => ZIO.succeed(schema)
 
   final def applyDataRowModifications(row: DataRow): Task[DataRow] =
     ZIO.foldLeft(modifications)(row)(applyDataRowModification)
@@ -29,11 +42,35 @@ abstract class DefaultStreamingSource(
   final def applySchemaModifications(schema: ArcaneSchema): Task[ArcaneSchema] =
     ZIO.foldLeft(modifications)(schema)(applySchemaModification)
 
-//  final override lazy val getSchema: Task[ArcaneSchema] = for
-//    source <- getSourceSchema
-//    ext    <- getSchemaExtensions(Seq.empty)
-//  yield source.appendedAll(ext)
-
   final override lazy val getSchema: Task[ArcaneSchema] =
     getSourceSchema.flatMap(applySchemaModifications)
+
+  private def addSurrogateMergeKey(row: DataRow): Task[DataRow] =
+    for
+      keys      <- primaryKeyNames
+      keyValues <- ZIO.foreach(keys)(getPrimaryKeyValue(row, _))
+      mergeKey  <- ZIO.attempt(createMergeKey(keyValues))
+    yield row.filterNot(_.name.equalsIgnoreCase(MergeKeyField.name)) :+ DataCell(
+      name = MergeKeyField.name,
+      Type = MergeKeyField.fieldType,
+      value = mergeKey
+    )
+
+  private def getPrimaryKeyValue(row: DataRow, key: String): Task[Any] =
+    ZIO
+      .fromOption(row.find(_.name.equalsIgnoreCase(key)))
+      .orElseFail(new IllegalArgumentException(s"Primary-key field '$key' is missing from the source row"))
+      .flatMap(cell =>
+        ZIO
+          .fromOption(Option(cell.value))
+          .orElseFail(new IllegalArgumentException(s"Primary-key field '$key' is null"))
+      )
+
+  private def createMergeKey(keyValues: Seq[Any]): String =
+    val input = keyValues.map(_.toString.take(128)).mkString("#")
+    val digest = MessageDigest
+      .getInstance("SHA-256")
+      .digest(input.getBytes(StandardCharsets.UTF_16LE))
+
+    HexFormat.of().formatHex(digest)
 }

--- a/src/main/scala/services/base/StreamingSource.scala
+++ b/src/main/scala/services/base/StreamingSource.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.base
 
 import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
-import models.settings.sources.{DataRowModification, SurrogateMergeKeyImpl}
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion, SurrogateMergeKeyImpl}
 
 import zio.{Task, ZIO}
 
@@ -16,24 +16,42 @@ trait PrimaryKeyProvider:
   protected def primaryKeyNames: Task[Seq[String]]
 
 abstract class DefaultStreamingSource(
-    protected val modifications: Seq[DataRowModification]
+    protected val modifications: Seq[DataRowModification],
+    protected val dataRowSchemaVersion: DataRowSchemaVersion
 ) extends StreamingSource
     with PrimaryKeyProvider {
+  require(
+    dataRowSchemaVersion != DataRowSchemaVersion.V1 ||
+      modifications.exists {
+        case SurrogateMergeKeyImpl(_) => true
+        case _                        => false
+      },
+    "Data-row schema V1 requires the surrogateMergeKey modification"
+  )
+
   protected def getSourceSchema: Task[ArcaneSchema]
 
   protected def applyDataRowModification(
       row: DataRow,
       modification: DataRowModification
   ): Task[DataRow] = modification match
-    case SurrogateMergeKeyImpl(_) => addSurrogateMergeKey(row)
-    case _                        => ZIO.succeed(row)
+    case SurrogateMergeKeyImpl(_) if dataRowSchemaVersion.usesCommonMergeKey =>
+      addSurrogateMergeKey(row)
+    case _ => ZIO.succeed(row)
 
   protected def applySchemaModification(
       schema: ArcaneSchema,
       modification: DataRowModification
   ): Task[ArcaneSchema] = modification match
-    case SurrogateMergeKeyImpl(_) if !schema.exists(_.name.equalsIgnoreCase(MergeKeyField.name)) =>
-      ZIO.succeed(schema.addField(MergeKeyField.name, MergeKeyField.fieldType))
+    case SurrogateMergeKeyImpl(_)
+        if dataRowSchemaVersion.usesCommonMergeKey &&
+          !schema.exists(_.name.equalsIgnoreCase(MergeKeyField.name)) =>
+      ZIO.succeed(
+        schema.addField(
+          MergeKeyField.name,
+          MergeKeyField.fieldType
+        )
+      )
     case _ => ZIO.succeed(schema)
 
   final def applyDataRowModifications(row: DataRow): Task[DataRow] =

--- a/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.blobsource.readers
 
 import models.schemas.ArcaneSchema
-import services.base.StreamingSource
+import services.base.DefaultStreamingSource
 import services.blobsource.versioning.BlobSourceWatermark
 import services.storage.models.base.StoredBlob
 import services.streaming.base.StructuredZStream
@@ -15,7 +15,7 @@ import java.util.Base64
 
 /** Base trait for all blob source readers
   */
-trait BlobStreamingSource extends StreamingSource:
+abstract class BlobStreamingSource extends DefaultStreamingSource(Seq.empty):
 
   final override type ShardMetadata = Seq[String]
   final override type WatermarkType = BlobSourceWatermark

--- a/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.blobsource.readers
 
 import models.schemas.ArcaneSchema
-import models.settings.sources.DataRowSchemaVersion
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import services.base.DefaultStreamingSource
 import services.blobsource.versioning.BlobSourceWatermark
 import services.storage.models.base.StoredBlob
@@ -16,7 +16,10 @@ import java.util.Base64
 
 /** Base trait for all blob source readers
   */
-abstract class BlobStreamingSource extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0):
+abstract class BlobStreamingSource(
+    modifications: Seq[DataRowModification],
+    dataRowSchemaVersion: DataRowSchemaVersion
+) extends DefaultStreamingSource(modifications, dataRowSchemaVersion):
 
   final override type ShardMetadata = Seq[String]
   final override type WatermarkType = BlobSourceWatermark

--- a/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/BlobStreamingSource.scala
@@ -2,6 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.blobsource.readers
 
 import models.schemas.ArcaneSchema
+import models.settings.sources.DataRowSchemaVersion
 import services.base.DefaultStreamingSource
 import services.blobsource.versioning.BlobSourceWatermark
 import services.storage.models.base.StoredBlob
@@ -15,7 +16,7 @@ import java.util.Base64
 
 /** Base trait for all blob source readers
   */
-abstract class BlobStreamingSource extends DefaultStreamingSource(Seq.empty):
+abstract class BlobStreamingSource extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0):
 
   final override type ShardMetadata = Seq[String]
   final override type WatermarkType = BlobSourceWatermark

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingCsvStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingCsvStreamingSource.scala
@@ -2,11 +2,11 @@ package com.sneaksanddata.arcane.framework
 package services.blobsource.readers.listing
 
 import models.schemas.{ArcaneSchema, DataRow}
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import services.blobsource.versioning.BlobSourceWatermark
 import services.naming.NameGenerator
 import services.storage.base.{BlobStorageReader, BlobStorageWriter}
 import services.storage.models.base.{BlobPath, StoredBlob}
-import services.streaming.base.StructuredZStream
 
 import zio.Task
 import zio.stream.ZStream
@@ -18,14 +18,18 @@ class BlobListingCsvStreamingSource[PathType <: BlobPath](
     nameGenerator: NameGenerator,
     schema: ArcaneSchema,
     primaryKeys: Seq[String],
-    tempStoragePath: String
+    tempStoragePath: String,
+    modifications: Seq[DataRowModification] = Seq.empty,
+    dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0
 ) extends BlobListingStreamingSource[PathType](
       sourcePath,
       shardStoragePath,
       storageClient,
       nameGenerator,
       primaryKeys,
-      tempStoragePath
+      tempStoragePath,
+      modifications,
+      dataRowSchemaVersion
     ):
 
   override protected def getSourceSchema: Task[SchemaType] = ???

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingCsvStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingCsvStreamingSource.scala
@@ -28,7 +28,7 @@ class BlobListingCsvStreamingSource[PathType <: BlobPath](
       tempStoragePath
     ):
 
-  override def getSchema: Task[SchemaType] = ???
+  override protected def getSourceSchema: Task[SchemaType] = ???
 
   /** Gets an empty schema.
     *

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
@@ -3,9 +3,9 @@ package services.blobsource.readers.listing
 
 import models.app.PluginStreamContext
 import models.batches.BlobBatchCommons
-import models.schemas.{ArcaneSchema, DataRow}
+import models.schemas.{ArcaneSchema, DataRow, MergeKeyField}
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import models.settings.sources.blob.JsonBlobSourceSettings
-import services.blobsource.versioning.BlobSourceWatermark
 import services.iceberg.given_Conversion_AvroSchema_ArcaneSchema
 import services.iceberg.interop.JsonScanner
 import services.naming.NameGenerator
@@ -28,14 +28,18 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
     primaryKeys: Seq[String],
     avroSchemaString: String,
     jsonPointerExpr: Option[String],
-    jsonArrayPointers: Map[String, Map[String, String]]
+    jsonArrayPointers: Map[String, Map[String, String]],
+    modifications: Seq[DataRowModification] = Seq.empty,
+    dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0
 ) extends BlobListingStreamingSource[PathType](
       sourcePath,
       shardStoragePath,
       storageClient,
       nameGenerator,
       primaryKeys,
-      tempStoragePath
+      tempStoragePath,
+      modifications,
+      dataRowSchemaVersion
     ):
 
   private def sourceSchema: Task[AvroSchema] = for
@@ -45,8 +49,11 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
       .orDieWith(e => Throwable("Invalid Avro schema provided for source", e))
   yield schema
 
-  override protected def getSourceSchema: Task[SchemaType] = for arcaneSchema <- sourceSchema.map(implicitly)
-  yield arcaneSchema ++ Seq(BlobBatchCommons.versionField)
+  override protected def getSourceSchema: Task[SchemaType] = sourceSchema.map { avroSchema =>
+    val originalSchema: ArcaneSchema = avroSchema
+    if dataRowSchemaVersion.usesCommonMergeKey then originalSchema ++ Seq(BlobBatchCommons.versionField)
+    else originalSchema ++ Seq(MergeKeyField, BlobBatchCommons.versionField)
+  }
 
   /** Gets an empty schema.
     *
@@ -61,7 +68,13 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
     scanner            <- ZIO.attempt(JsonScanner(downloadedFilePath, avroSchema, jsonPointerExpr, jsonArrayPointers))
   yield (
     scanner.getRows.map(
-      BlobBatchCommons.enrichBatchRow(_, sourceFile.createdOn.getOrElse(0), primaryKeys, mergeKeyHasher())
+      BlobBatchCommons.enrichBatchRow(
+        _,
+        sourceFile.createdOn.getOrElse(0),
+        primaryKeys,
+        mergeKeyHasher(),
+        !dataRowSchemaVersion.usesCommonMergeKey
+      )
     ),
     schema
   )
@@ -84,7 +97,13 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
             }
             .flatMap(
               _.getRows.map(
-                BlobBatchCommons.enrichBatchRow(_, sourceFile.createdOn.getOrElse(0), primaryKeys, mergeKeyHasher())
+                BlobBatchCommons.enrichBatchRow(
+                  _,
+                  sourceFile.createdOn.getOrElse(0),
+                  primaryKeys,
+                  mergeKeyHasher(),
+                  !dataRowSchemaVersion.usesCommonMergeKey
+                )
               )
             )
         },
@@ -121,6 +140,8 @@ object BlobListingJsonStreamingSource:
         nameGenerator = nameGenerator,
         avroSchemaString = sourceSettings.avroSchemaString,
         jsonPointerExpr = sourceSettings.jsonPointerExpression,
-        jsonArrayPointers = sourceSettings.jsonArrayPointers
+        jsonArrayPointers = sourceSettings.jsonArrayPointers,
+        modifications = context.source.modifications.modifications,
+        dataRowSchemaVersion = context.source.dataRowSchemaVersion
       )
     }

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
@@ -67,15 +67,17 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
     avroSchema         <- sourceSchema
     scanner            <- ZIO.attempt(JsonScanner(downloadedFilePath, avroSchema, jsonPointerExpr, jsonArrayPointers))
   yield (
-    scanner.getRows.map(
-      BlobBatchCommons.enrichBatchRow(
-        _,
-        sourceFile.createdOn.getOrElse(0),
-        primaryKeys,
-        mergeKeyHasher(),
-        !dataRowSchemaVersion.usesCommonMergeKey
+    scanner.getRows
+      .map(
+        BlobBatchCommons.enrichBatchRow(
+          _,
+          sourceFile.createdOn.getOrElse(0),
+          primaryKeys,
+          mergeKeyHasher(),
+          !dataRowSchemaVersion.usesCommonMergeKey
+        )
       )
-    ),
+      .mapZIO(applyDataRowModifications),
     schema
   )
 
@@ -96,15 +98,17 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
               yield scanner
             }
             .flatMap(
-              _.getRows.map(
-                BlobBatchCommons.enrichBatchRow(
-                  _,
-                  sourceFile.createdOn.getOrElse(0),
-                  primaryKeys,
-                  mergeKeyHasher(),
-                  !dataRowSchemaVersion.usesCommonMergeKey
+              _.getRows
+                .map(
+                  BlobBatchCommons.enrichBatchRow(
+                    _,
+                    sourceFile.createdOn.getOrElse(0),
+                    primaryKeys,
+                    mergeKeyHasher(),
+                    !dataRowSchemaVersion.usesCommonMergeKey
+                  )
                 )
-              )
+                .mapZIO(applyDataRowModifications)
             )
         },
       schema

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingJsonStreamingSource.scala
@@ -45,7 +45,7 @@ class BlobListingJsonStreamingSource[PathType <: BlobPath](
       .orDieWith(e => Throwable("Invalid Avro schema provided for source", e))
   yield schema
 
-  override def getSchema: Task[SchemaType] = for arcaneSchema <- sourceSchema.map(implicitly)
+  override protected def getSourceSchema: Task[SchemaType] = for arcaneSchema <- sourceSchema.map(implicitly)
   yield arcaneSchema ++ Seq(BlobBatchCommons.versionField)
 
   /** Gets an empty schema.

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
@@ -40,7 +40,7 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
       tempStoragePath
     ):
 
-  override def getSchema: Task[SchemaType] = for
+  override protected def getSourceSchema: Task[SchemaType] = for
     preconfiguredSchema <- ZIO.when(sourceSchema.isDefined) {
       for
         schemaBytes <- ZIO.attempt(Base64.getDecoder.decode(sourceSchema.get))

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
@@ -7,9 +7,9 @@ import models.app.PluginStreamContext
 import models.batches.BlobBatchCommons
 import models.schemas.{*, given}
 import models.settings.sources.blob.ParquetBlobSourceSettings
-import services.blobsource.versioning.BlobSourceWatermark
-import services.iceberg.given_Conversion_Schema_ArcaneSchema
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import services.iceberg.interop.ParquetScanner
+import services.iceberg.{given_Conversion_Schema_Seq, inferMergeKeyIndex}
 import services.naming.NameGenerator
 import services.storage.base.{BlobStorageReader, BlobStorageWriter}
 import services.storage.models.base.{BlobPath, StoredBlob}
@@ -17,6 +17,7 @@ import services.storage.models.s3.S3StoragePath
 import services.storage.services.s3.S3BlobStorageService
 import services.streaming.base.StructuredZStream
 
+import org.apache.iceberg.Schema
 import zio.stream.ZStream
 import zio.{Task, ZIO, ZLayer}
 
@@ -30,14 +31,18 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
     tempStoragePath: String,
     primaryKeys: Seq[String],
     useNameMapping: Boolean,
-    sourceSchema: Option[String]
+    sourceSchema: Option[String],
+    modifications: Seq[DataRowModification] = Seq.empty,
+    dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0
 ) extends BlobListingStreamingSource[PathType](
       sourcePath,
       shardStoragePath,
       storageClient,
       nameGenerator,
       primaryKeys,
-      tempStoragePath
+      tempStoragePath,
+      modifications,
+      dataRowSchemaVersion
     ):
 
   override protected def getSourceSchema: Task[SchemaType] = for
@@ -45,10 +50,10 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
       for
         schemaBytes <- ZIO.attempt(Base64.getDecoder.decode(sourceSchema.get))
         scanner     <- ZIO.attempt(ParquetScanner(schemaBytes, useNameMapping))
-        schema      <- scanner.getIcebergSchema.map(implicitly)
+        schema      <- scanner.getIcebergSchema
       yield schema
     }
-    runtimeSchema <- preconfiguredSchema match
+    icebergSchema <- preconfiguredSchema match
       case Some(schema) => ZIO.succeed(schema)
       case None =>
         for
@@ -58,7 +63,7 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
           maybeFilePath <- storageClient.downloadRandomBlob(sourcePath, tempStoragePath)
           schema <- maybeFilePath match
             case Some(filePath) =>
-              ZIO.attempt(ParquetScanner(filePath, useNameMapping)).flatMap(_.getIcebergSchema.map(implicitly))
+              ZIO.attempt(ParquetScanner(filePath, useNameMapping)).flatMap(_.getIcebergSchema)
             case None =>
               ZIO.fail(
                 FatalStreamFailException(
@@ -66,10 +71,22 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
                 )
               )
         yield schema
-  yield runtimeSchema ++ Seq(BlobBatchCommons.indexedVersionField(runtimeSchema.mergeKey match {
-    case IndexedMergeKeyField(fieldId) => fieldId + 1
-    case _ => throw FatalStreamFailException("Unsupported schema: parquet source supplied a non-indexed merge key")
-  }))
+
+    originalFields: Seq[IndexedField] = summon[
+      Conversion[org.apache.iceberg.Schema, Seq[IndexedField]]
+    ].apply(icebergSchema)
+    originalSchema = ArcaneSchema(originalFields)
+    nextFieldId    = inferMergeKeyIndex(icebergSchema.columns().getLast)
+  yield
+    if dataRowSchemaVersion.usesCommonMergeKey then
+      originalSchema ++ Seq(
+        BlobBatchCommons.indexedVersionField(nextFieldId)
+      )
+    else
+      originalSchema ++ Seq(
+        IndexedMergeKeyField(nextFieldId),
+        BlobBatchCommons.indexedVersionField(nextFieldId + 1)
+      )
 
   /** Gets an empty schema.
     *
@@ -83,7 +100,13 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
     scanner            <- ZIO.attempt(ParquetScanner(downloadedFilePath, useNameMapping))
   yield (
     scanner.getRows.map(
-      BlobBatchCommons.enrichBatchRow(_, sourceFile.createdOn.getOrElse(0), primaryKeys, mergeKeyHasher())
+      BlobBatchCommons.enrichBatchRow(
+        _,
+        sourceFile.createdOn.getOrElse(0),
+        primaryKeys,
+        mergeKeyHasher(),
+        !dataRowSchemaVersion.usesCommonMergeKey
+      )
     ),
     schema
   )
@@ -105,7 +128,13 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
             }
             .flatMap(
               _.getRows.map(
-                BlobBatchCommons.enrichBatchRow(_, sourceFile.createdOn.getOrElse(0), primaryKeys, mergeKeyHasher())
+                BlobBatchCommons.enrichBatchRow(
+                  _,
+                  sourceFile.createdOn.getOrElse(0),
+                  primaryKeys,
+                  mergeKeyHasher(),
+                  !dataRowSchemaVersion.usesCommonMergeKey
+                )
               )
             )
         },
@@ -142,6 +171,8 @@ object BlobListingParquetStreamingSource:
         tempStoragePath = sourceSettings.tempStoragePath,
         primaryKeys = sourceSettings.primaryKeys,
         useNameMapping = sourceSettings.useNameMapping,
-        sourceSchema = sourceSettings.sourceSchema
+        sourceSchema = sourceSettings.sourceSchema,
+        modifications = context.source.modifications.modifications,
+        dataRowSchemaVersion = context.source.dataRowSchemaVersion
       )
     }

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingParquetStreamingSource.scala
@@ -99,15 +99,17 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
     downloadedFilePath <- downloadSourceFile(sourceFile)
     scanner            <- ZIO.attempt(ParquetScanner(downloadedFilePath, useNameMapping))
   yield (
-    scanner.getRows.map(
-      BlobBatchCommons.enrichBatchRow(
-        _,
-        sourceFile.createdOn.getOrElse(0),
-        primaryKeys,
-        mergeKeyHasher(),
-        !dataRowSchemaVersion.usesCommonMergeKey
+    scanner.getRows
+      .map(
+        BlobBatchCommons.enrichBatchRow(
+          _,
+          sourceFile.createdOn.getOrElse(0),
+          primaryKeys,
+          mergeKeyHasher(),
+          !dataRowSchemaVersion.usesCommonMergeKey
+        )
       )
-    ),
+      .mapZIO(applyDataRowModifications),
     schema
   )
 
@@ -127,15 +129,17 @@ class BlobListingParquetStreamingSource[PathType <: BlobPath](
               yield scanner
             }
             .flatMap(
-              _.getRows.map(
-                BlobBatchCommons.enrichBatchRow(
-                  _,
-                  sourceFile.createdOn.getOrElse(0),
-                  primaryKeys,
-                  mergeKeyHasher(),
-                  !dataRowSchemaVersion.usesCommonMergeKey
+              _.getRows
+                .map(
+                  BlobBatchCommons.enrichBatchRow(
+                    _,
+                    sourceFile.createdOn.getOrElse(0),
+                    primaryKeys,
+                    mergeKeyHasher(),
+                    !dataRowSchemaVersion.usesCommonMergeKey
+                  )
                 )
-              )
+                .mapZIO(applyDataRowModifications)
             )
         },
       schema

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingStreamingSource.scala
@@ -26,6 +26,7 @@ abstract class BlobListingStreamingSource[PathType <: BlobPath](
 ) extends BlobStreamingSource:
 
   protected val parallelism: Int = Runtime.getRuntime.availableProcessors()
+  override protected val primaryKeyNames: Task[Seq[String]] = ZIO.succeed(primaryKeys)
 
   override def fileToBlob(sourceFile: String): Task[StoredBlob] = storageClient.blobMetadata(sourceFile)
 

--- a/src/main/scala/services/blobsource/readers/listing/BlobListingStreamingSource.scala
+++ b/src/main/scala/services/blobsource/readers/listing/BlobListingStreamingSource.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.blobsource.readers.listing
 
 import logging.ZIOLogAnnotations.{zlog, zlogStream}
-import models.schemas.{ArcaneSchema, given_CanAdd_ArcaneSchema}
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import services.blobsource.readers.BlobStreamingSource
 import services.blobsource.versioning.BlobSourceWatermark
 import services.naming.NameGenerator
@@ -22,10 +22,12 @@ abstract class BlobListingStreamingSource[PathType <: BlobPath](
     storageClient: BlobStorageReader[PathType] & BlobStorageWriter[PathType],
     nameGenerator: NameGenerator,
     primaryKeys: Seq[String],
-    tempStoragePath: String
-) extends BlobStreamingSource:
+    tempStoragePath: String,
+    modifications: Seq[DataRowModification],
+    dataRowSchemaVersion: DataRowSchemaVersion
+) extends BlobStreamingSource(modifications, dataRowSchemaVersion):
 
-  protected val parallelism: Int = Runtime.getRuntime.availableProcessors()
+  protected val parallelism: Int                            = Runtime.getRuntime.availableProcessors()
   override protected val primaryKeyNames: Task[Seq[String]] = ZIO.succeed(primaryKeys)
 
   override def fileToBlob(sourceFile: String): Task[StoredBlob] = storageClient.blobMetadata(sourceFile)

--- a/src/main/scala/services/iceberg/SchemaConversions.scala
+++ b/src/main/scala/services/iceberg/SchemaConversions.scala
@@ -118,12 +118,14 @@ def unfoldAvroUnion(field: AvroSchema.Field): AvroSchema.Type =
 
 given Conversion[AvroSchema, ArcaneSchema] with
   override def apply(avroSchema: AvroSchema): ArcaneSchema =
-    ArcaneSchema(avroSchema.getFields.asScala.map { avroField =>
-      Field(
-        name = avroField.name(),
-        fieldType = unfoldAvroUnion(avroField)
-      )
-    }.toSeq ++ Seq(MergeKeyField))
+    ArcaneSchema(
+      avroSchema.getFields.asScala.map { avroField =>
+        Field(
+          name = avroField.name(),
+          fieldType = unfoldAvroUnion(avroField)
+        )
+      }.toSeq
+    )
 
 given Conversion[AvroType, ArcaneType] with
   override def apply(avroType: AvroType): ArcaneType = avroType match

--- a/src/main/scala/services/mssql/QueryProvider.scala
+++ b/src/main/scala/services/mssql/QueryProvider.scala
@@ -27,13 +27,16 @@ object QueryProvider:
     def getSchemaQuery: Task[MsSqlQuery] =
       for
         columnSummaries <- reader.getColumnSummaries
-        mergeExpression  = QueryProvider.getMergeExpression(columnSummaries, "tq")
-        columnExpression = QueryProvider.getChangeTrackingColumns(columnSummaries, "ct", "tq")
-        matchStatement   = QueryProvider.getMatchStatement(columnSummaries, "ct", "tq", None)
+        maybeMergeExpression = Option.when(reader.usesLegacyMergeKey)(
+          QueryProvider.getMergeExpression(columnSummaries, "ct")
+        )
+        mergeKeyColumnExpression = maybeMergeExpression.fold("")(getLegacyMergeKeyColumnExpression)
+        columnExpression         = QueryProvider.getChangeTrackingColumns(columnSummaries, "ct", "tq")
+        matchStatement           = QueryProvider.getMatchStatement(columnSummaries, "ct", "tq", None)
         query <- QueryProvider.getChangesQuery(
           reader.connectionSettings,
           reader.catalog,
-          mergeExpression,
+          mergeKeyColumnExpression,
           columnExpression,
           matchStatement,
           Long.MaxValue
@@ -53,13 +56,16 @@ object QueryProvider:
     def getChangesQuery(fromVersion: Long): Task[MsSqlQuery] =
       for
         columnSummaries <- reader.getColumnSummaries
-        mergeExpression  = QueryProvider.getMergeExpression(columnSummaries, "ct")
-        columnExpression = QueryProvider.getChangeTrackingColumns(columnSummaries, "ct", "tq")
-        matchStatement   = QueryProvider.getMatchStatement(columnSummaries, "ct", "tq", None)
+        maybeMergeExpression = Option.when(reader.usesLegacyMergeKey)(
+          QueryProvider.getMergeExpression(columnSummaries, "ct")
+        )
+        mergeKeyColumnExpression = maybeMergeExpression.fold("")(getLegacyMergeKeyColumnExpression)
+        columnExpression         = QueryProvider.getChangeTrackingColumns(columnSummaries, "ct", "tq")
+        matchStatement           = QueryProvider.getMatchStatement(columnSummaries, "ct", "tq", None)
         query <- QueryProvider.getChangesQuery(
           reader.connectionSettings,
           reader.catalog,
-          mergeExpression,
+          mergeKeyColumnExpression,
           columnExpression,
           matchStatement,
           fromVersion
@@ -80,14 +86,17 @@ object QueryProvider:
         columnSummaries: List[ColumnSummary]
     ): Task[MsSqlQuery] =
       for
-        mergeExpression  = QueryProvider.getMergeExpression(columnSummaries, "tq")
-        columnExpression = QueryProvider.getChangeTrackingColumns(columnSummaries, "tq")
+        maybeMergeExpression = Option.when(reader.usesLegacyMergeKey)(
+          QueryProvider.getMergeExpression(columnSummaries, "tq")
+        )
+        mergeKeyColumnExpression = maybeMergeExpression.fold("")(getLegacyMergeKeyColumnExpression)
+        columnExpression         = QueryProvider.getChangeTrackingColumns(columnSummaries, "tq")
         query <- QueryProvider.getAllQuery(
           reader.connectionSettings,
           reader.catalog,
           shardSchemaName,
           shardTableName,
-          mergeExpression,
+          mergeKeyColumnExpression,
           columnExpression
         )
       yield query
@@ -274,7 +283,7 @@ object QueryProvider:
   private def getChangesQuery(
       connectionSettings: MsSqlServerDatabaseSourceSettings,
       databaseName: String,
-      mergeExpression: String,
+      mergeKeyColumnExpression: String,
       columnStatement: String,
       matchStatement: String,
       changeTrackingId: Long
@@ -291,8 +300,7 @@ object QueryProvider:
           .replace("{tableName}", connectionSettings.tableName)
           .replace("{ChangeTrackingColumnsStatement}", columnStatement)
           .replace("{ChangeTrackingMatchStatement}", matchStatement)
-          .replace("{MERGE_EXPRESSION}", mergeExpression)
-          .replace("{MERGE_KEY}", MergeKeyField.name)
+          .replace("{OptionalMergeKeyColumnExpression}", mergeKeyColumnExpression)
           .replace("{lastId}", changeTrackingId.toString)
       yield query
     }
@@ -302,7 +310,7 @@ object QueryProvider:
       databaseName: String,
       schemaName: String,
       tableName: String,
-      mergeExpression: String,
+      mergeKeyColumnExpression: String,
       columnExpression: String
   ): Task[MsSqlQuery] =
     ZIO.scoped {
@@ -316,7 +324,16 @@ object QueryProvider:
           .replace("{schema}", schemaName)
           .replace("{tableName}", tableName)
           .replace("{ChangeTrackingColumnsStatement}", columnExpression)
-          .replace("{MERGE_EXPRESSION}", mergeExpression)
-          .replace("{MERGE_KEY}", MergeKeyField.name)
+          .replace("{OptionalMergeKeyColumnExpression}", mergeKeyColumnExpression)
       yield query
     }
+
+  private def getLegacyMergeKeyColumnExpression(mergeExpression: String): String =
+    s""",
+       |lower(
+       |  convert(
+       |    nvarchar(128),
+       |    HashBytes('SHA2_256', $mergeExpression),
+       |    2
+       |  )
+       |) AS [${MergeKeyField.name}]""".stripMargin

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -37,8 +37,10 @@ import scala.annotation.tailrec
 class MsSqlStreamingSource(
     val connectionSettings: MsSqlServerDatabaseSourceSettings,
     fieldSelector: ColumnSummaryFieldSelector,
-    nameGenerator: NameGenerator
-) extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0)
+    nameGenerator: NameGenerator,
+    modifications: Seq[DataRowModification] = Seq.empty,
+    dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0
+) extends DefaultStreamingSource(modifications, dataRowSchemaVersion)
     with AutoCloseable:
 
   override type ShardMetadata = String
@@ -100,10 +102,11 @@ class MsSqlStreamingSource(
           stream <- ZStream.unfoldZIO(resultSet.next()) { hasNext =>
             if hasNext then
               for
-                columns    <- ZIO.attemptBlockingInterrupt(resultSet.getMetaData.getColumnCount)
-                row        <- ZIO.fromTry(toDataRow(resultSet, columns, List.empty))
-                hasNextRow <- ZIO.attemptBlockingInterrupt(resultSet.next())
-              yield Some((row.handleSpecialTypes, hasNextRow))
+                columns     <- ZIO.attemptBlockingInterrupt(resultSet.getMetaData.getColumnCount)
+                row         <- ZIO.fromTry(toDataRow(resultSet, columns, List.empty))
+                modifiedRow <- applyDataRowModifications(row.handleSpecialTypes)
+                hasNextRow  <- ZIO.attemptBlockingInterrupt(resultSet.next())
+              yield Some((modifiedRow, hasNextRow))
             else ZIO.succeed(None)
           }
         yield stream,
@@ -184,7 +187,8 @@ class MsSqlStreamingSource(
             yield MsSqlStreamingSource.ensureHead(result)
           })
           .flatMap(batch => unfoldBatch(batch))
-          .map(_.handleSpecialTypes),
+          .map(_.handleSpecialTypes)
+          .mapZIO(applyDataRowModifications),
         schema
       )
     }
@@ -475,9 +479,11 @@ object MsSqlStreamingSource:
           context       <- ZIO.service[PluginStreamContext]
           nameGenerator <- ZIO.service[NameGenerator]
         yield new MsSqlStreamingSource(
-          extractor(context),
-          new ColumnSummaryFieldSelector(context.source.fieldSelectionRule),
-          nameGenerator
+          connectionSettings = extractor(context),
+          fieldSelector = new ColumnSummaryFieldSelector(context.source.fieldSelectionRule),
+          nameGenerator = nameGenerator,
+          modifications = context.source.modifications.modifications,
+          dataRowSchemaVersion = context.source.dataRowSchemaVersion
         )
       }
     }

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -38,7 +38,7 @@ class MsSqlStreamingSource(
     val connectionSettings: MsSqlServerDatabaseSourceSettings,
     fieldSelector: ColumnSummaryFieldSelector,
     nameGenerator: NameGenerator
-) extends DefaultStreamingSource(Seq.empty)
+) extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0)
     with AutoCloseable:
 
   override type ShardMetadata = String
@@ -456,6 +456,8 @@ class MsSqlStreamingSource(
           populateShardTable(tableName, id, profile.shardCount, profile.summaries)
         }
     }
+
+  private[mssql] def usesLegacyMergeKey: Boolean = !dataRowSchemaVersion.usesCommonMergeKey
 
 object MsSqlStreamingSource:
 

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -528,18 +528,20 @@ class MsSqlStreamingSource(
           )
       }
 
-  // TODO: is this equivalent to MS SQL Server query? is UTF-8 used by SQL SERVER?
-  // TODO: cast(value as nvarchar(128)) vs Java.toString
   private def createMergeKey(keyValues: Seq[Any]): String =
     val input =
       keyValues
-        .map(_.toString)
+        .map {
+          case s: String => s.take(128)
+          case null      => throw new IllegalArgumentException("PK value must not be null")
+          case other     => throw new UnsupportedOperationException(s"Unsupported PK type: ${other.getClass.getName}")
+        }
         .mkString("#")
 
     val digest =
       MessageDigest
         .getInstance("SHA-256")
-        .digest(input.getBytes(StandardCharsets.UTF_8))
+        .digest(input.getBytes(StandardCharsets.UTF_16LE))
 
     HexFormat.of().formatHex(digest)
 

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -3,9 +3,10 @@ package services.mssql.base
 
 import logging.ZIOLogAnnotations.{zlog, zlogStream}
 import models.app.PluginStreamContext
-import models.schemas.{ArcaneSchema, DataRow, given_CanAdd_ArcaneSchema}
+import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
 import models.settings.mssql.MsSqlServerDatabaseSourceSettings
-import services.base.{SchemaProvider, StreamingSource}
+import models.settings.sources.*
+import services.base.{DefaultStreamingSource, SchemaProvider, StreamingSource}
 import services.mssql.QueryProvider.{getBackfillQuery, getChangesQuery, getSchemaQuery}
 import services.mssql.given_Conversion_SqlSchema_ArcaneSchema
 import services.mssql.base.MsSqlStreamingSource.{closeSafe, executeQuerySafe}
@@ -16,15 +17,18 @@ import services.mssql.*
 import services.mssql.given_Conversion_SqlDataRow_DataRow
 import services.streaming.base.StructuredZStream
 import services.naming.NameGenerator
+import services.mssql.SqlDataCell.normalizeName
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver
 import zio.stream.ZStream
 import zio.{Scope, Task, UIO, ZIO, ZLayer}
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.sql.{Connection, ResultSet, Statement}
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
-import java.util.Properties
+import java.util.{HexFormat, Properties}
 import scala.annotation.tailrec
 
 /** Represents a connection to a Microsoft SQL Server database.
@@ -36,8 +40,8 @@ class MsSqlStreamingSource(
     val connectionSettings: MsSqlServerDatabaseSourceSettings,
     fieldSelector: ColumnSummaryFieldSelector,
     nameGenerator: NameGenerator
-) extends AutoCloseable
-    with StreamingSource:
+) extends DefaultStreamingSource(Seq.empty)
+    with AutoCloseable:
 
   override type ShardMetadata = String
   override type WatermarkType = MsSqlWatermark
@@ -63,6 +67,14 @@ class MsSqlStreamingSource(
       )
       result <- executeColumnSummariesQuery(query)
     yield result
+
+  // TODO: is Task result content cached?
+  private lazy val primaryKeyNames: Task[Seq[String]] =
+    getColumnSummaries.map(
+      _.collect { case (name, true) =>
+        name.normalizeName
+      }
+    )
 
   /** Create a stream from a provided shard table.
     */
@@ -274,7 +286,7 @@ class MsSqlStreamingSource(
     * @return
     *   An effect containing the schema for the data produced by Arcane.
     */
-  override lazy val getSchema: Task[this.SchemaType] =
+  override val getSourceSchema: Task[this.SchemaType] =
     for
       query     <- this.getSchemaQuery
       sqlSchema <- getSqlSchema(query)
@@ -447,6 +459,89 @@ class MsSqlStreamingSource(
           populateShardTable(tableName, id, profile.shardCount, profile.summaries)
         }
     }
+
+  override protected def applyDataRowModification(
+      row: DataRow,
+      modification: DataRowModification
+  ): Task[DataRow] =
+    modification match
+      case SurrogateMergeKeyImpl(_) =>
+        primaryKeyNames.flatMap(addSurrogateMergeKey(row, _))
+      case unsupported =>
+        ZIO.fail(
+          new UnsupportedOperationException(
+            s"Unsupported MSSQL data-row modification: $unsupported"
+          )
+        )
+
+  override protected def applySchemaModification(
+      schema: ArcaneSchema,
+      modification: DataRowModification
+  ): Task[ArcaneSchema] =
+    modification match {
+      case SurrogateMergeKeyImpl(_) =>
+        ZIO.succeed(
+          schema.addField(
+            MergeKeyField.name,
+            MergeKeyField.fieldType
+          )
+        )
+      case unsupported =>
+        ZIO.fail(
+          new UnsupportedOperationException(
+            s"Unsupported MSSQL data-row modification: $unsupported"
+          )
+        )
+    }
+
+  private def addSurrogateMergeKey(
+      row: DataRow,
+      primaryKeys: Seq[String]
+  ): Task[DataRow] =
+    for
+      keyValues <- ZIO.foreach(primaryKeys)(getPrimaryKeyValue(row, _))
+      mergeKey  <- ZIO.attempt(createMergeKey(keyValues))
+    yield row :+ DataCell(
+      name = MergeKeyField.name,
+      Type = MergeKeyField.fieldType,
+      value = mergeKey
+    )
+
+  private def getPrimaryKeyValue(
+      row: DataRow,
+      key: String
+  ): Task[Any] =
+    ZIO
+      .fromOption(row.find(_.name.equalsIgnoreCase(key)))
+      .orElseFail(
+        new IllegalArgumentException(
+          s"Primary-key field '$key' is missing from the MSSQL row"
+        )
+      )
+      .flatMap { cell =>
+        ZIO
+          .fromOption(Option(cell.value))
+          .orElseFail(
+            new IllegalArgumentException(
+              s"Primary-key field '$key' is null"
+            )
+          )
+      }
+
+  // TODO: is this equivalent to MS SQL Server query? is UTF-8 used by SQL SERVER?
+  // TODO: cast(value as nvarchar(128)) vs Java.toString
+  private def createMergeKey(keyValues: Seq[Any]): String =
+    val input =
+      keyValues
+        .map(_.toString)
+        .mkString("#")
+
+    val digest =
+      MessageDigest
+        .getInstance("SHA-256")
+        .digest(input.getBytes(StandardCharsets.UTF_8))
+
+    HexFormat.of().formatHex(digest)
 
 object MsSqlStreamingSource:
 

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -3,7 +3,7 @@ package services.mssql.base
 
 import logging.ZIOLogAnnotations.{zlog, zlogStream}
 import models.app.PluginStreamContext
-import models.schemas.{ArcaneSchema, DataCell, DataRow, MergeKeyField, given_CanAdd_ArcaneSchema}
+import models.schemas.{ArcaneSchema, DataRow, given_CanAdd_ArcaneSchema}
 import models.settings.mssql.MsSqlServerDatabaseSourceSettings
 import models.settings.sources.*
 import services.base.{DefaultStreamingSource, SchemaProvider, StreamingSource}
@@ -23,12 +23,10 @@ import com.microsoft.sqlserver.jdbc.SQLServerDriver
 import zio.stream.ZStream
 import zio.{Scope, Task, UIO, ZIO, ZLayer}
 
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import java.sql.{Connection, ResultSet, Statement}
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
-import java.util.{HexFormat, Properties}
+import java.util.Properties
 import scala.annotation.tailrec
 
 /** Represents a connection to a Microsoft SQL Server database.
@@ -68,8 +66,7 @@ class MsSqlStreamingSource(
       result <- executeColumnSummariesQuery(query)
     yield result
 
-  // TODO: is Task result content cached?
-  private lazy val primaryKeyNames: Task[Seq[String]] =
+  override protected val primaryKeyNames: Task[Seq[String]] =
     getColumnSummaries.map(
       _.collect { case (name, true) =>
         name.normalizeName
@@ -459,91 +456,6 @@ class MsSqlStreamingSource(
           populateShardTable(tableName, id, profile.shardCount, profile.summaries)
         }
     }
-
-  override protected def applyDataRowModification(
-      row: DataRow,
-      modification: DataRowModification
-  ): Task[DataRow] =
-    modification match
-      case SurrogateMergeKeyImpl(_) =>
-        primaryKeyNames.flatMap(addSurrogateMergeKey(row, _))
-      case unsupported =>
-        ZIO.fail(
-          new UnsupportedOperationException(
-            s"Unsupported MSSQL data-row modification: $unsupported"
-          )
-        )
-
-  override protected def applySchemaModification(
-      schema: ArcaneSchema,
-      modification: DataRowModification
-  ): Task[ArcaneSchema] =
-    modification match {
-      case SurrogateMergeKeyImpl(_) =>
-        ZIO.succeed(
-          schema.addField(
-            MergeKeyField.name,
-            MergeKeyField.fieldType
-          )
-        )
-      case unsupported =>
-        ZIO.fail(
-          new UnsupportedOperationException(
-            s"Unsupported MSSQL data-row modification: $unsupported"
-          )
-        )
-    }
-
-  private def addSurrogateMergeKey(
-      row: DataRow,
-      primaryKeys: Seq[String]
-  ): Task[DataRow] =
-    for
-      keyValues <- ZIO.foreach(primaryKeys)(getPrimaryKeyValue(row, _))
-      mergeKey  <- ZIO.attempt(createMergeKey(keyValues))
-    yield row :+ DataCell(
-      name = MergeKeyField.name,
-      Type = MergeKeyField.fieldType,
-      value = mergeKey
-    )
-
-  private def getPrimaryKeyValue(
-      row: DataRow,
-      key: String
-  ): Task[Any] =
-    ZIO
-      .fromOption(row.find(_.name.equalsIgnoreCase(key)))
-      .orElseFail(
-        new IllegalArgumentException(
-          s"Primary-key field '$key' is missing from the MSSQL row"
-        )
-      )
-      .flatMap { cell =>
-        ZIO
-          .fromOption(Option(cell.value))
-          .orElseFail(
-            new IllegalArgumentException(
-              s"Primary-key field '$key' is null"
-            )
-          )
-      }
-
-  private def createMergeKey(keyValues: Seq[Any]): String =
-    val input =
-      keyValues
-        .map {
-          case s: String => s.take(128)
-          case null      => throw new IllegalArgumentException("PK value must not be null")
-          case other     => throw new UnsupportedOperationException(s"Unsupported PK type: ${other.getClass.getName}")
-        }
-        .mkString("#")
-
-    val digest =
-      MessageDigest
-        .getInstance("SHA-256")
-        .digest(input.getBytes(StandardCharsets.UTF_16LE))
-
-    HexFormat.of().formatHex(digest)
 
 object MsSqlStreamingSource:
 

--- a/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
+++ b/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
@@ -8,7 +8,7 @@ import models.cdm.given_Conversion_String_ArcaneSchema_DataRow
 import models.schemas.ArcaneType.*
 import models.schemas.{*, given}
 import models.settings.sources.synapse.MicrosoftSynapseLinkConnectionSettings
-import services.base.{SchemaProvider, StreamingSource}
+import services.base.{DefaultStreamingSource, SchemaProvider}
 import services.storage.models.azure.AdlsStoragePath
 import services.storage.models.base.StoredBlob
 import services.storage.services.azure.AzureBlobStorageReader
@@ -25,14 +25,15 @@ import java.time.*
 import java.time.format.DateTimeFormatter
 
 final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: String, reader: AzureBlobStorageReader)
-    extends StreamingSource:
+    extends DefaultStreamingSource(Seq.empty):
 
   override type ShardMetadata = (stream: StructuredZStream, source: String)
   override type WatermarkType = SynapseWatermark
+  override protected val primaryKeyNames: Task[Seq[String]] = ZIO.succeed(Seq("Id"))
 
   /** Schema here comes from root-level model.json
     */
-  override def getSchema: Task[ArcaneSchema] =
+  override protected def getSourceSchema: Task[ArcaneSchema] =
     SynapseEntitySchemaProvider(reader, location.toHdfsPath, entityName).getSchema
 
   /** Schema from batch-level model.json

--- a/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
+++ b/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
@@ -4,12 +4,12 @@ package services.synapse.base
 import extensions.BufferedReaderExtensions.*
 import logging.ZIOLogAnnotations.{zlog, zlogStream}
 import models.app.PluginStreamContext
-import models.cdm.given_Conversion_String_ArcaneSchema_DataRow
+import models.cdm.CSVParser
 import models.schemas.ArcaneType.*
 import models.schemas.{*, given}
+import models.settings.sources.{DataRowModification, DataRowSchemaVersion}
 import models.settings.sources.synapse.MicrosoftSynapseLinkConnectionSettings
-import models.settings.sources.DataRowSchemaVersion
-import services.base.{DefaultStreamingSource, SchemaProvider}
+import services.base.DefaultStreamingSource
 import services.storage.models.azure.AdlsStoragePath
 import services.storage.models.base.StoredBlob
 import services.storage.services.azure.AzureBlobStorageReader
@@ -25,8 +25,13 @@ import java.io.{BufferedReader, IOException}
 import java.time.*
 import java.time.format.DateTimeFormatter
 
-final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: String, reader: AzureBlobStorageReader)
-    extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0):
+final class SynapseLinkStreamingSource(
+    location: AdlsStoragePath,
+    entityName: String,
+    reader: AzureBlobStorageReader,
+    modifications: Seq[DataRowModification] = Seq.empty,
+    dataRowSchemaVersion: DataRowSchemaVersion = DataRowSchemaVersion.V0
+) extends DefaultStreamingSource(modifications, dataRowSchemaVersion):
 
   override type ShardMetadata = (stream: StructuredZStream, source: String)
   override type WatermarkType = SynapseWatermark
@@ -35,12 +40,18 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
   /** Schema here comes from root-level model.json
     */
   override protected def getSourceSchema: Task[ArcaneSchema] =
-    SynapseEntitySchemaProvider(reader, location.toHdfsPath, entityName).getSchema
+    SynapseEntitySchemaProvider(reader, location.toHdfsPath, entityName).getSchema.map(prepareSourceSchema)
 
   /** Schema from batch-level model.json
     */
   private def getBatchSchema(batchFolderName: String): Task[ArcaneSchema] =
     SynapseEntitySchemaProvider(reader, (location + batchFolderName).toHdfsPath, entityName).getSchema
+      .map(prepareSourceSchema)
+      .flatMap(applySchemaModifications)
+
+  private def prepareSourceSchema(schema: ArcaneSchema): ArcaneSchema =
+    if dataRowSchemaVersion.usesCommonMergeKey then schema
+    else schema.addIndexedField(MergeKeyField.name, MergeKeyField.fieldType)
 
   override def empty: ArcaneSchema = ArcaneSchema.empty()
 
@@ -57,43 +68,44 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
     .streamPrefixes(location + batchFolderName + entityName + "/")
     .filter(sb => sb.name.endsWith(".csv"))
 
-  private def enrichWithSchema(prefix: String): ZStream[Any, Throwable, SchemaEnrichedBlob] = {
+  private def enrichWithSchema(
+      prefix: String,
+      batchSchema: ArcaneSchema
+  ): ZStream[Any, Throwable, SchemaEnrichedBlob] =
     ZStream
-      .fromZIO(for
-        files <- getBatchFiles(prefix).runCollect // materialize CSV list to avoid double-querying storage
-        _ <- zlog(
-          "Found %s CSV files with changes for entity %s at batch folder %s",
-          files.size.toString,
-          entityName,
-          prefix
-        )
-        dataBlobs <- ZIO.when(files.nonEmpty) {
-          for
-            // getSchema here performs runtime check for model.json for the batch to be parseable and readable
-            // this will hard fail compared to `hasSchemaFile` just filtering invalid batches out.
-            // this allows to separate batch filtering for eligibility for processing, from batch data correctness checks
-            orderedFiles <- SynapseEntitySchemaProvider(
-              reader,
-              (location + prefix).toHdfsPath,
-              entityName
-            ).getSchema.map(schema =>
-              files
-                // we need to emit deletions, which are in files named 1.csv, last
-                // otherwise for batches where deletions come alongside insertions there is a risk of running a delete BEFORE the insert
-                .sortBy(b => b.name.split("/").last.replace(".csv", "").toInt)(using Ordering.Int.reverse)
-                .map(csvBlob => SchemaEnrichedBlob(csvBlob, schema))
-            )
-          yield orderedFiles
-        }
-      yield dataBlobs)
-      .flatMap {
-        case Some(files) =>
-          zlogStream("Starting stream of the following: %s", files.map(_.blob.name).mkString(",")) *> ZStream
-            .fromIterable(files)
-        case None =>
-          zlogStream("Batch %s has no changes for the entity %s", prefix, entityName) *> ZStream.empty
+      .fromZIO {
+        for
+          files <- getBatchFiles(prefix).runCollect
+          _ <- zlog(
+            "Found %s CSV files with changes for entity %s at batch folder %s",
+            files.size.toString,
+            entityName,
+            prefix
+          )
+        yield files
       }
-  }
+      .flatMap { files =>
+        if files.nonEmpty then
+          val schemaEnrichedFiles =
+            files
+              // we need to emit deletions, which are in files named 1.csv, last
+              // otherwise for batches where deletions come alongside insertions there is a risk of running a delete BEFORE the insert
+              .sortBy(
+                _.name.split("/").last.replace(".csv", "").toInt
+              )(using Ordering.Int.reverse)
+              .map(blob => SchemaEnrichedBlob(blob, batchSchema))
+
+          zlogStream(
+            "Starting stream of the following: %s",
+            schemaEnrichedFiles.map(_.blob.name).mkString(",")
+          ) *> ZStream.fromIterable(schemaEnrichedFiles)
+        else
+          zlogStream(
+            "Batch %s has no changes for the entity %s",
+            prefix,
+            entityName
+          ) *> ZStream.empty
+      }
 
   /** Select ALL CSV files that correspond to the entity changes
     *
@@ -103,8 +115,11 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
     * @return
     *   A stream of rows for this table
     */
-  private def getEntityChangeData(version: SynapseWatermark): ZStream[Any, Throwable, SchemaEnrichedBlob] =
-    enrichWithSchema(version.prefix)
+  private def getEntityChangeData(
+      version: SynapseWatermark,
+      batchSchema: ArcaneSchema
+  ): ZStream[Any, Throwable, SchemaEnrichedBlob] =
+    enrichWithSchema(version.prefix, batchSchema)
 
   private def getFileStream(
       seb: SchemaEnrichedBlob
@@ -124,7 +139,9 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
       .flatMap(javaReader => javaReader.streamMultilineCsv)
       .map(_.replace("\n", ""))
       .map(content => SchemaEnrichedContent(content, fileSchema))
-      .mapZIO(sec => ZIO.attempt(implicitly[DataRow](using sec.content, sec.schema)))
+      .mapZIO(sec =>
+        ZIO.attempt(CSVParser.parseCSVLineToRow(sec.content, sec.schema, !dataRowSchemaVersion.usesCommonMergeKey))
+      )
       .mapError(e => new IOException(s"Failed to parse CSV content: ${e.getMessage} from file: $fileName with", e))
 
   private def isValidSynapseBatch(prefix: String): ZIO[Any, Throwable, Boolean] = hasSchemaFile(prefix)
@@ -156,7 +173,11 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
   def getChanges(version: SynapseWatermark): ZStream[Any, Throwable, StructuredZStream] = reader
     .getEligibleDates(storagePath = location, startFrom = version.timestamp)
     .map(_.asWatermark)
-    .mapZIO(wm => getBatchSchema(wm.prefix).map(batchSchema => (getChangesForVersion(wm), batchSchema)))
+    .mapZIO { watermark =>
+      getBatchSchema(watermark.prefix).map { batchSchema =>
+        (getChangesForVersion(watermark, batchSchema), batchSchema)
+      }
+    }
 
   /** Converts an arbitrary timestamp into a matching watermark
     * @return
@@ -169,13 +190,17 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
     *
     * @return
     */
-  private def getChangesForVersion(version: SynapseWatermark): ZStream[Any, Throwable, DataRow] =
-    getEntityChangeData(version)
+  private def getChangesForVersion(
+      version: SynapseWatermark,
+      batchSchema: ArcaneSchema
+  ): ZStream[Any, Throwable, DataRow] =
+    getEntityChangeData(version, batchSchema)
       .mapZIO(getFileStream)
       .flatMap { case (fileStream, fileSchema, blob) =>
         getTableChanges(fileStream, fileSchema, blob.name)
       }
       .map(convertRow)
+      .mapZIO(applyDataRowModifications)
 
   private def getWatermarks(startAt: SynapseWatermark, endAt: SynapseWatermark): Task[Seq[SynapseWatermark]] =
     reader.getDateRange(location, startAt.timestamp, endAt.timestamp).map(_.map(_.asWatermark))
@@ -184,7 +209,11 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
     watermark <- ZIO.succeed(StoredBlob(name = folder, createdOn = None).asWatermark)
     result <- ZIO.ifZIO(isValidSynapseBatch(watermark.prefix))(
       getBatchSchema(watermark.prefix)
-        .map(batchSchema => Some((stream = (getChangesForVersion(watermark), batchSchema), source = watermark.prefix))),
+        .map { batchSchema =>
+          Some(
+            (stream = (getChangesForVersion(watermark, batchSchema), batchSchema), source = watermark.prefix)
+          )
+        },
       ZIO.succeed(None)
     )
   yield result
@@ -267,15 +296,21 @@ final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: St
     ZStream
       .fromZIO(getWatermarks(rangeStart, rangeEnd))
       .flatMap(ZStream.fromIterable(_))
-      .filterZIO(wm => isValidSynapseBatch(wm.prefix))
-      .mapZIO(wm =>
-        getBatchSchema(wm.prefix)
-          .map(batchSchema => (stream = (getChangesForVersion(wm), batchSchema), source = wm.prefix))
+      .filterZIO(watermark => isValidSynapseBatch(watermark.prefix))
+      .mapZIO(watermark =>
+        getBatchSchema(watermark.prefix)
+          .map { batchSchema =>
+            (stream = (getChangesForVersion(watermark, batchSchema), batchSchema), source = watermark.prefix)
+          }
       )
 
 object SynapseLinkStreamingSource:
   def apply(reader: AzureBlobStorageReader, name: String, location: AdlsStoragePath): SynapseLinkStreamingSource =
-    new SynapseLinkStreamingSource(location, name, reader)
+    new SynapseLinkStreamingSource(
+      location = location,
+      entityName = name,
+      reader = reader
+    )
 
   private type SettingsExtractor = PluginStreamContext => MicrosoftSynapseLinkConnectionSettings
 
@@ -287,9 +322,11 @@ object SynapseLinkStreamingSource:
       for
         context  <- ZIO.service[PluginStreamContext]
         settings <- ZIO.attempt(extractor(context))
-      yield SynapseLinkStreamingSource(
-        AzureBlobStorageReader(settings.storageConnection),
-        settings.entityName,
-        settings.baseLocation
+      yield new SynapseLinkStreamingSource(
+        reader = AzureBlobStorageReader(settings.storageConnection),
+        entityName = settings.entityName,
+        location = settings.baseLocation,
+        modifications = context.source.modifications.modifications,
+        dataRowSchemaVersion = context.source.dataRowSchemaVersion
       )
     }

--- a/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
+++ b/src/main/scala/services/synapse/base/SynapseLinkStreamingSource.scala
@@ -8,6 +8,7 @@ import models.cdm.given_Conversion_String_ArcaneSchema_DataRow
 import models.schemas.ArcaneType.*
 import models.schemas.{*, given}
 import models.settings.sources.synapse.MicrosoftSynapseLinkConnectionSettings
+import models.settings.sources.DataRowSchemaVersion
 import services.base.{DefaultStreamingSource, SchemaProvider}
 import services.storage.models.azure.AdlsStoragePath
 import services.storage.models.base.StoredBlob
@@ -25,7 +26,7 @@ import java.time.*
 import java.time.format.DateTimeFormatter
 
 final class SynapseLinkStreamingSource(location: AdlsStoragePath, entityName: String, reader: AzureBlobStorageReader)
-    extends DefaultStreamingSource(Seq.empty):
+    extends DefaultStreamingSource(Seq.empty, DataRowSchemaVersion.V0):
 
   override type ShardMetadata = (stream: StructuredZStream, source: String)
   override type WatermarkType = SynapseWatermark


### PR DESCRIPTION
The goal of this PR is to introduce more generalized (among the sources) schema/data modification approach over DataRow entries, in order to support simple modifications such as adding `arcane_merge_key` column. These changes should lay foundation to enable the addition of new modifications simple (e.g.`arcane_insterted_at` column).


Changes so far summary:

SQL Server:
- V0 schema/change/backfill queries inject the legacy SQL merge key.
- V1 queries omit it.
- V1 schema uses the common schema modifier.
- Change-capture and backfill rows use the common row modifier.
- Production layer propagates version and modifications.
- Compatibility factory defaults to V0.

Synapse:
- CDM conversion now produces a pure source schema.
- V0 root and batch schemas add the legacy indexed key.
- V1 root and batch schemas use the common modifier.
- V0 CSV parsing copies Id as the legacy key.
- V1 rows use the common modifier after type conversion.
- Streaming and both backfill paths use the same implementation.
- Batch schema is loaded once and reused for parsing and stream metadata.
- Production wiring and V0 compatibility factory are present.

Blob JSON:
- V0 schema and rows receive the legacy key.
- V1 schema and rows use common modifications.
- createdon is retained in both versions.
- Single-file and multi-file/backfill paths apply row modifications.
- Production layer wiring is present.

Blob Parquet:
- V0 schema adds indexed merge-key and version fields.
- V1 schema adds indexed version, followed by the common indexed merge key.
- Field IDs remain unique.
- V0 and V1 row order matches their corresponding schemas.
- Single-file and multi-file/backfill paths apply row modifications.
- Production layer wiring is present.