### PR TITLE
[Memory Bound Shaper] mprove memory heuristic for narrow tables and cap chunk size

### DIFF
--- a/src/main/scala/models/settings/streaming/ThroughputSettings.scala
+++ b/src/main/scala/models/settings/streaming/ThroughputSettings.scala
@@ -20,7 +20,8 @@ case class MemoryBound(
     chunkCostMax: Int,
     tableRowCountWeight: Double,
     tableSizeWeight: Double,
-    tableSizeScaleFactor: Int
+    tableSizeScaleFactor: Int,
+    chunkSizeCap: Int
 ) derives ReadWriter
 
 /** ADT composed with settings class for MemoryBound

--- a/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
+++ b/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
@@ -83,68 +83,113 @@ class MemoryBoundShaper(
         .sum * 1.5 / recordCount / 2L).toLong
 
   private def estimateRowSize(schema: Schema, estimatedStringLength: Long): Long =
-    schema.columns().asScala.map(_.`type`()).foldLeft(0L) { case (agg, tp) =>
-      val typeSize = tp.typeId() match
+    // rows in Arcane memory are List[DataRow]
+    // 4 bytes for list pointer
+    // object header: 12 bytes
+    // head: 4 bytes (pointing to the DataCell object)
+    // tail: 4 bytes (pointing to the next List element or Nil)
+    // padding: 4 bytes
+    val dataRowOuterSize = 4L + 12L + 4L + 4L + 4L
+    // object header + `name` field for `DataCell` class
+    val dataCellSizeBase = 12L + 32L + 16L + 4L
+
+    // add outer size to each cell to be found based on schema
+    // cell has name, type def and value. Estimate type def size and value size based on schema
+    dataRowOuterSize + schema.columns().asScala.map(_.`type`()).foldLeft(0L) { case (agg, tp) =>
+      val cellValueSize = tp.typeId() match
         // 8L added to each type to hold pointer, since all types are objects
         // 16L for Java object header, ignore COH to be on the safe side
         // add 4L for padding for all except boolean
         case TypeID.TIME =>
-          4L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 4L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.INTEGER =>
-          4L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 4L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.BOOLEAN =>
-          1L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 11L // padding
+          (
+            valueSize = 1L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 11L,       // padding
+            typeSize = 0L
+          )
         case TypeID.LONG =>
-          8L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 8L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.FLOAT =>
-          4L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 4L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.DOUBLE =>
-          8L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 8L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.STRING =>
-          32L     // wrapper type
-            + 16L // array header
-            + 2L * estimatedStringLength
+          (
+            valueSize = 32L // wrapper type
+              + 16L         // array header
+              + 2L * estimatedStringLength,
+            typeSize = 0L
+          )
         case TypeID.DECIMAL =>
-          16L         // header
-            + 8L      // bigint pointer
-            + 4L + 4L // scale and precision
-            + 16L     // bingint wrapper header
-            + 8L      // array pointer
-            + 4L + 4L // sign and length
-            + 16L     // extra metadata
-            + 32L     // data array
+          (
+            valueSize = 16L // header
+              + 8L          // bigint pointer
+              + 4L + 4L     // scale and precision
+              + 16L         // bingint wrapper header
+              + 8L          // array pointer
+              + 4L + 4L     // sign and length
+              + 16L         // extra metadata
+              + 32L,        // data array
+            typeSize = 12L + 4L + 4L
+          )
         case TypeID.TIMESTAMP =>
-          8L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 8L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case TypeID.TIMESTAMP_NANO =>
-          8L      // data
-            + 8L  // pointer
-            + 16L // header
-            + 4L  // padding
+          (
+            valueSize = 8L // data
+              + 8L         // pointer
+              + 16L        // header
+              + 4L,        // padding
+            typeSize = 0L
+          )
         case _ =>
-          16L + 4L + 8L + shaperSettings.objectTypeSizeEstimate.toLong // assume large size for structs, lists, geometry, variant and other less common types
+          (
+            valueSize = 16L + 4L + 8L + shaperSettings.objectTypeSizeEstimate.toLong,
+            typeSize = 24L + 256L
+          ) // assume large size for structs, lists, geometry, variant and other less common types
 
-      agg + typeSize
+      agg + cellValueSize.typeSize + cellValueSize.valueSize + dataCellSizeBase
     }
 
   override def estimateChunkSize: Task[(Elements: Int, ElementSize: Long)] = for
@@ -180,9 +225,12 @@ class MemoryBoundShaper(
     }
 
     chunkSizeFromRowSize <- ZIO.succeed(
-      getTotalFreeMemory * estimationCache(memCacheKey) / (estimationCache(
-        rowSizeCacheKey
-      ) + 1) / 2 // estimate for 2 chunks in memory at all times
+      Seq(
+        getTotalFreeMemory * estimationCache(memCacheKey) / (estimationCache(
+          rowSizeCacheKey
+        ) + 1) / 2, // estimate for 2 chunks in memory at all times
+        1_000_000   // cap at 1 million rows
+      ).min
     )
     _ <- zlog("Estimated chunk size %s for the current stream", chunkSizeFromRowSize.toInt.toString)
     appliedSize <- ZIO.succeed(

--- a/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
+++ b/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
@@ -83,7 +83,7 @@ class MemoryBoundShaper(
         .sum * 1.5 / recordCount / 2L).toLong
 
   private def estimateRowSize(schema: Schema, estimatedStringLength: Long): Long =
-    // rows in Arcane memory are List[DataRow]
+    // rows in Arcane memory are List[DataCell]
     // 4 bytes for list pointer
     // object header: 12 bytes
     // head: 4 bytes (pointing to the DataCell object)

--- a/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
+++ b/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
@@ -229,7 +229,7 @@ class MemoryBoundShaper(
         getTotalFreeMemory * estimationCache(memCacheKey) / (estimationCache(
           rowSizeCacheKey
         ) + 1) / 2,                          // estimate for 2 chunks in memory at all times
-        shaperSettings.chunkSizeCap.toDouble // cap at 1 million rows
+        shaperSettings.chunkSizeCap.toDouble // cap at chunkSizeCap rows
       ).min
     )
     _ <- zlog("Estimated chunk size %s for the current stream", chunkSizeFromRowSize.toInt.toString)

--- a/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
+++ b/src/main/scala/services/streaming/throughput/MemoryBoundShaper.scala
@@ -228,8 +228,8 @@ class MemoryBoundShaper(
       Seq(
         getTotalFreeMemory * estimationCache(memCacheKey) / (estimationCache(
           rowSizeCacheKey
-        ) + 1) / 2, // estimate for 2 chunks in memory at all times
-        1_000_000   // cap at 1 million rows
+        ) + 1) / 2,                          // estimate for 2 chunks in memory at all times
+        shaperSettings.chunkSizeCap.toDouble // cap at 1 million rows
       ).min
     )
     _ <- zlog("Estimated chunk size %s for the current stream", chunkSizeFromRowSize.toInt.toString)

--- a/src/test/scala/tests/services/streaming/throughput/MemoryBoundShaperTests.scala
+++ b/src/test/scala/tests/services/streaming/throughput/MemoryBoundShaperTests.scala
@@ -32,7 +32,7 @@ object MemoryBoundShaperTests extends ZIOSpecDefault:
     targetTableShortName = tableName,
     memoryBoundShaperSettings = new ThroughputSettings {
       override val shaperImpl: ThroughputShaperImpl =
-        MemoryBoundImpl(MemoryBound(stringSize, 4096, 1, 10, 0.5, 0.5, 2))
+        MemoryBoundImpl(MemoryBound(stringSize, 4096, 1, 10, 0.5, 0.5, 2, 1000000000))
       override val advisedChunkSize: Int = 10
       override val advisedRate: FlowRate = FlowRate(elements = 1, interval = Duration.ofSeconds(10))
       override val advisedBurst: Int     = 10
@@ -67,7 +67,7 @@ object MemoryBoundShaperTests extends ZIOSpecDefault:
         chunkSize        <- shaper.estimateChunkSize
         flowRate         <- shaper.estimateShapeRate(chunkSize.Elements, chunkSize.ElementSize)
         currentMemory    <- ZIO.succeed(javaRuntime.maxMemory() - javaRuntime.totalMemory() + javaRuntime.freeMemory())
-        expectedRowSize  <- ZIO.succeed(stringSize * 2 + 32 + 16)
+        expectedRowSize  <- ZIO.succeed(28 + stringSize * 2 + 32 + 16 + 64)
         expectedElements <- ZIO.succeed(0.2 * currentMemory / (expectedRowSize + 1) / 2)
       // no GC - default 1 for count -> 0.999 probability / 10s interval -> 10% rate uplift
       yield assertTrue(
@@ -111,7 +111,7 @@ object MemoryBoundShaperTests extends ZIOSpecDefault:
         chunkSize     <- shaper.estimateChunkSize
         currentMemory <- ZIO.succeed(javaRuntime.maxMemory() - javaRuntime.totalMemory() + javaRuntime.freeMemory())
         // 2 strings of length 10 with 50% buffer and one integer
-        expectedRowSize  <- ZIO.succeed(2 * ((10 * 1.5) * 2 + 32 + 16) + (4 + 8 + 16 + 4))
+        expectedRowSize  <- ZIO.succeed(28 + 2 * ((10 * 1.5) * 2 + 32 + 16 + 64) + (4 + 8 + 16 + 4 + 64))
         expectedElements <- ZIO.succeed(0.7999 * currentMemory / (expectedRowSize + 1) / 2)
         _                <- ZIO.attempt(javaRuntime.gc())
         flowRate         <- shaper.estimateShapeRate(chunkSize.Elements, chunkSize.ElementSize)

--- a/src/test/scala/tests/settings/ThroughputSettingsTests.scala
+++ b/src/test/scala/tests/settings/ThroughputSettingsTests.scala
@@ -26,7 +26,8 @@ class ThroughputSettingsTests extends AnyFlatSpec with Matchers:
               chunkCostMax = 1,
               tableRowCountWeight = 1,
               tableSizeWeight = 1,
-              tableSizeScaleFactor = 1
+              tableSizeScaleFactor = 1,
+              chunkSizeCap = 10
             )
           ),
           static = None
@@ -35,7 +36,7 @@ class ThroughputSettingsTests extends AnyFlatSpec with Matchers:
         advisedRate = FlowRate(elements = 1, interval = Duration.ofSeconds(5)),
         advisedBurst = 1
       ),
-      """{"shaperImpl":{"memoryBound":{"fallbackStringTypeSizeEstimate":1,"objectTypeSizeEstimate":1,"chunkCostScale":1,"chunkCostMax":1,"tableRowCountWeight":1,"tableSizeWeight":1,"tableSizeScaleFactor":1}},"advisedRate":"1 per 5 seconds","advisedBurst":1,"advisedChunkSize":1}"""
+      """{"shaperImpl":{"memoryBound":{"fallbackStringTypeSizeEstimate":1,"objectTypeSizeEstimate":1,"chunkCostScale":1,"chunkCostMax":1,"tableRowCountWeight":1,"tableSizeWeight":1,"tableSizeScaleFactor":1,"chunkSizeCap":10}},"advisedRate":"1 per 5 seconds","advisedBurst":1,"advisedChunkSize":1}"""
     ),
     (
       DefaultThroughputSettings(

--- a/src/test/scala/tests/shared/TestThroughputShaperBuilder.scala
+++ b/src/test/scala/tests/shared/TestThroughputShaperBuilder.scala
@@ -16,7 +16,7 @@ object TestThroughputShaperBuilder:
     ThroughputShaperBuilder(
       new ThroughputSettings {
         override val shaperImpl: ThroughputShaperImpl =
-          MemoryBoundImpl(MemoryBound(1000, 4096, 1, 10, 0.5, 0.5, 2))
+          MemoryBoundImpl(MemoryBound(1000, 4096, 1, 10, 0.5, 0.5, 2, 1000000))
         override val advisedChunkSize: Int = 10
         override val advisedRate: FlowRate = FlowRate(elements = 1, interval = Duration.ofSeconds(10))
         override val advisedBurst: Int     = 10


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/arcane-framework-scala/issues/447

- Refactored the `estimateRowSize` to include previously missing estimate of `List[]` and `DataCell` boilerplate that wraps values received from source.
- Added a hard cap to the estimated chunk size, ensuring that no chunk will exceed `chunkSizeCap` rows regardless of available memory or schema. This is done to prevent creating objects that garbage collector will struggle to manage, esp on low tier machines w/o much CPU cache.

