### PR TITLE
[MsSql] Revert MsSql time resolver changes and fix double UTC shift

### DIFF
--- a/src/main/scala/services/mssql/QueryProvider.scala
+++ b/src/main/scala/services/mssql/QueryProvider.scala
@@ -202,7 +202,7 @@ object QueryProvider:
     */
   def getVersionFromTimestampQuery(startFrom: OffsetDateTime, formatter: DateTimeFormatter): MsSqlQuery =
     val formattedTime = formatter.format(startFrom)
-    s"SELECT ISNULL(MIN(commit_ts), CAST(0 AS BIGINT)) FROM sys.dm_tran_commit_table WHERE commit_time >= '$formattedTime'"
+    s"SELECT MIN(commit_ts) FROM sys.dm_tran_commit_table WHERE commit_time >= '$formattedTime'"
 
   /** Retrieve commit time associated with the provided version
     */

--- a/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
+++ b/src/main/scala/services/mssql/base/MsSqlStreamingSource.scala
@@ -214,9 +214,7 @@ class MsSqlStreamingSource(
     def readTime(resultSet: ResultSet): Option[OffsetDateTime] =
       resultSet.getMetaData.getColumnType(1) match
         case java.sql.Types.TIMESTAMP =>
-          Option(resultSet.getTimestamp(1)).flatMap(v =>
-            Some(OffsetDateTime.ofInstant(Instant.ofEpochMilli(v.getTime), ZoneOffset.UTC))
-          )
+          Option(resultSet.getTimestamp(1)).flatMap(v => Some(Instant.ofEpochMilli(v.getTime).atOffset(ZoneOffset.UTC)))
         case _ =>
           throw new IllegalArgumentException(
             s"Invalid column type for change tracking version: ${resultSet.getMetaData.getColumnType(1)}, expected TIMESTAMP"

--- a/src/test/scala/tests/mssql/MsSqlStreamingSourceTests.scala
+++ b/src/test/scala/tests/mssql/MsSqlStreamingSourceTests.scala
@@ -162,9 +162,7 @@ object MsSqlStreamingSourceTests extends ZIOSpecDefault:
         query       <- ZIO.succeed(QueryProvider.getVersionFromTimestampQuery(currentTime, formatter))
         formatted   <- ZIO.succeed(formatter.format(currentTime))
       yield assertTrue(
-        query.contains("SELECT ISNULL(MIN(commit_ts), CAST(0 AS BIGINT))") && query.contains(
-          s"WHERE commit_time >= '$formatted'"
-        )
+        query.contains("SELECT MIN(commit_ts)") && query.contains(s"WHERE commit_time >= '$formatted'")
       )
     },
     test("QueryProvider generates backfill query") {


### PR DESCRIPTION
Also fixes double-utc shift in MsSql timestamp